### PR TITLE
Ecosystem, design review, and style refinement: trust surface, sandboxes, Tailwind preset, rounded themes, Next.js template, MCP server, one visual grammar

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,25 @@
+labels: ["idea"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Floating an idea before it's a formal request? Perfect place for it.
+        Concrete, fully-specified proposals can also go straight to a
+        [feature request](https://github.com/DaxAvalon/voidframe-ui/issues/new?template=feature_request.yml).
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: The idea
+      description: What would you like voidframe-ui to do, and who would it help?
+    validations:
+      required: true
+
+  - type: textarea
+    id: shape
+    attributes:
+      label: Rough shape (optional)
+      description: Any thoughts on the API, component name, or how it'd be themed through `--vf-*` tokens.
+      render: tsx
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,34 @@
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Asking how to do something with voidframe-ui? Great — fill this in so
+        people can help quickly. If you've found a clear bug, file a
+        [bug report](https://github.com/DaxAvalon/voidframe-ui/issues/new?template=bug_report.yml)
+        instead.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: What are you trying to do?
+      description: Describe the goal and what you've tried so far.
+    validations:
+      required: true
+
+  - type: textarea
+    id: code
+    attributes:
+      label: Relevant code
+      description: A snippet or a StackBlitz/CodeSandbox link makes this much easier to answer.
+      render: tsx
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: voidframe-ui version
+      placeholder: "1.3.0"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Something in voidframe-ui behaves incorrectly.
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please **do not** use this
+        form for security vulnerabilities — report those privately via the
+        [Security advisories](https://github.com/DaxAvalon/voidframe-ui/security/advisories)
+        page instead.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I searched [existing issues](https://github.com/DaxAvalon/voidframe-ui/issues?q=is%3Aissue) and this is not a duplicate.
+          required: true
+        - label: I am on the latest `voidframe-ui` release (or have stated which version below).
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: voidframe-ui version
+      description: Output of `npm ls voidframe-ui`.
+      placeholder: "1.3.0"
+    validations:
+      required: true
+
+  - type: input
+    id: react-version
+    attributes:
+      label: React version
+      placeholder: "18.3.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      description: Where does the bug occur?
+      multiple: true
+      options:
+        - Client-side render (CSR)
+        - Server-side render (SSR) / hydration
+        - Static export
+        - Test environment (jsdom / Vitest / Jest)
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: >
+        A StackBlitz/CodeSandbox link or a minimal code snippet (component,
+        props, and steps). Reports with a runnable reproduction are fixed far
+        faster.
+      render: tsx
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Console output / stack trace
+      description: Paste any errors or warnings. This is automatically formatted.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & ideas (Discussions)
+    url: https://github.com/DaxAvalon/voidframe-ui/discussions
+    about: Ask "how do I…", share what you built, or float an idea before filing a request.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/DaxAvalon/voidframe-ui/security/advisories/new
+    about: Report security issues privately via a GitHub Security Advisory — never in a public issue.
+  - name: 📖 Documentation
+    url: https://daxavalon.github.io/voidframe-ui
+    about: Component reference, guides, and live playgrounds.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature request
+description: Suggest a component, prop, or capability for voidframe-ui.
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Open-ended ideas and "would it make sense to…" questions are often a
+        better fit for [Discussions](https://github.com/DaxAvalon/voidframe-ui/discussions).
+        Use this form when you have a concrete proposal.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I searched existing issues and discussions and this is not a duplicate.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to build, and where does voidframe-ui fall short today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: >
+        The API you have in mind — component name, props, behaviour. A code
+        sketch of how you'd want to call it is ideal.
+      render: tsx
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing components or workarounds you tried, and why they fall short.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: constraints
+    attributes:
+      label: Fit with voidframe's design language
+      description: Voidframe is a dark, monochrome, terminal-brutalist system themed entirely through `--vf-*` tokens.
+      options:
+        - label: This proposal can be themed through the existing `--vf-*` token system (no hard-coded colors).
+          required: false
+        - label: I'm willing to help implement this with a PR.
+          required: false

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ import { VoidframeProvider } from "voidframe-ui";
 
 ### Built-in themes
 
-Four themes ship out of the box: `darkTheme` (default), `lightTheme`, `midnightTheme` (deep-black OLED-friendly), and `greyTheme` (neutral mid-grey for print and projection). Pass any of them to `VoidframeProvider`'s `theme` prop or address them by name via `themeName="dark" | "light" | "midnight" | "grey" | "system"`.
+Six themes ship out of the box: `darkTheme` (default), `lightTheme`, `midnightTheme` (deep-black OLED-friendly), `greyTheme` (neutral mid-grey for print and projection), and the rounded pair `softTheme` / `softLightTheme` (lower-contrast surfaces with rounded corners — the deliberate opt-out of the brutalist zero-radius default). Pass any of them to `VoidframeProvider`'s `theme` prop or address them by name via `themeName="dark" | "light" | "midnight" | "grey" | "soft" | "soft-light" | "system"`.
 
 ```jsx
 import { VoidframeProvider } from "voidframe-ui";

--- a/README.md
+++ b/README.md
@@ -1133,6 +1133,23 @@ Demo entry: `demo/App.tsx`. Sections are defined as plain components and registe
 
 ---
 
+## AI agents (MCP)
+
+Coding with an AI assistant? The **`voidframe-mcp`** [Model Context Protocol](https://modelcontextprotocol.io) server exposes the full component / hook / utility catalog — exact names, props, types, and signatures — so agents look APIs up instead of guessing.
+
+```jsonc
+// Claude Desktop, Cursor (.cursor/mcp.json), etc.
+{
+  "mcpServers": {
+    "voidframe": { "command": "npx", "args": ["-y", "voidframe-mcp"] }
+  }
+}
+```
+
+Tools: `list_components`, `get_component`, `list_hooks`, `get_hook`, `list_utils`, `get_util`, and a unified `search`. It's a zero-dependency stdio server over the same structured data behind the docs site and `llms.txt`. See [`tools/mcp/README.md`](tools/mcp/README.md).
+
+---
+
 ## Build
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -382,6 +382,30 @@ function MyComponent() {
 }
 ```
 
+### Tailwind preset
+
+If you use Tailwind, the bundled preset exposes every `--vf-*` token as a
+Tailwind utility. Values resolve to CSS custom properties, so utilities
+re-theme automatically when `VoidframeProvider` swaps the active theme.
+
+```js
+// tailwind.config.js
+module.exports = {
+  presets: [require("voidframe-ui/tailwind")],
+};
+```
+
+```html
+<div class="bg-vf-bg-1 text-vf-text-0 border border-vf-border-2 p-vf-4 font-vf-mono">
+  <span class="text-vf-green bg-vf-green-10 px-vf-2">OK</span>
+</div>
+```
+
+Scales: `vf-bg-*` / `vf-text-*` / `vf-border-*` colors, accents with
+`5/10/20/40/60` opacity steps, `vf-success|danger|warning|info`, spacing
+`vf-1`→`vf-12`, font family/size, line-height, letter-spacing, border radius,
+border width, and `vf-sm`→`vf-xxl` breakpoints.
+
 ---
 
 ## Design Tokens

--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ Use `@axe-core/playwright` for per-route browser-level a11y checks. For visual r
 
 Voidframe is SSR-safe and carries `"use client"` directives on every stateful module, so it works out of the box with Next.js (App + Pages Router), Remix, Astro, Vite SSR, and Gatsby. A `renderToString` smoke test exercises a representative sample of every complexity tier on every commit.
 
-**Next.js (App Router):** wrap the root layout in a thin client wrapper — this keeps the rest of the layout server-rendered while carving out a single client boundary for `VoidframeProvider`.
+**Next.js (App Router):** scaffold a ready-made project with `npm create voidframe-app@latest my-app --template next`, or wire it by hand — wrap the root layout in a thin client wrapper, which keeps the rest of the layout server-rendered while carving out a single client boundary for `VoidframeProvider`.
 
 ```tsx
 // app/providers.tsx

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,110 @@
+# Security Policy
+
+Voidframe is a client-side React component library. It ships **zero runtime
+dependencies** (every heavy capability — charts, QR/barcode, flow diagrams,
+HTML sanitisation — is a *peer* dependency you install and version yourself),
+which keeps the attack surface we are responsible for small and auditable.
+
+This document explains which versions receive fixes, how to report a
+vulnerability privately, and what to expect after you do.
+
+## Supported versions
+
+Security fixes are published for the latest released minor line. Older lines
+do not receive backports; upgrading within the same major is always
+non-breaking by policy (see [CHANGELOG.md](./CHANGELOG.md)).
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.3.x   | :white_check_mark: |
+| < 1.3   | :x: (please upgrade) |
+
+The current release is **1.3.0**.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately through GitHub's coordinated-disclosure channel:
+
+1. Go to the [**Security** tab](https://github.com/DaxAvalon/voidframe-ui/security/advisories).
+2. Click **Report a vulnerability**.
+3. Describe the issue, including affected version(s), a reproduction or proof
+   of concept, and the impact you have in mind.
+
+A private advisory keeps the discussion confidential between you and the
+maintainers until a fix is ready and coordinated disclosure is agreed.
+
+### What to include
+
+- The affected package version (`npm ls voidframe-ui`) and React version.
+- A minimal reproduction — a component, props, and the observed vs. expected
+  behaviour. CodeSandbox/StackBlitz links are welcome.
+- The security impact you foresee (e.g. XSS, prototype pollution, ReDoS).
+
+### Response targets
+
+These are goals, not contractual guarantees, for a small maintainer team:
+
+| Stage                         | Target            |
+| ----------------------------- | ----------------- |
+| Acknowledge the report        | within 3 days     |
+| Initial assessment / severity | within 7 days     |
+| Fix or mitigation plan        | within 30 days    |
+
+We will keep you updated through the advisory thread and credit you in the
+release notes and advisory unless you ask to remain anonymous.
+
+## Scope
+
+Voidframe renders UI in the browser. The classes of issue most relevant to a
+component library are:
+
+- **Cross-site scripting (XSS)** through component props that end up in the
+  DOM. Voidframe does **not** call `dangerouslySetInnerHTML` on untrusted
+  input on your behalf; components that render rich/markup content (e.g. chat
+  and markdown surfaces) require **`dompurify`** as a peer dependency and
+  expect sanitised input. If you find a path where attacker-controlled props
+  reach the DOM unescaped, that is in scope.
+- **Prototype pollution / ReDoS** in utility helpers, hooks, or token parsing.
+- **Supply-chain integrity** of the published `voidframe-ui` package (see
+  below).
+
+The following are **out of scope** here (report to the respective project):
+
+- Vulnerabilities in peer dependencies (React, d3-*, `@xyflow/react`,
+  `dompurify`, `jsbarcode`, `qrcode-generator`, `topojson-client`, etc.). We
+  will help coordinate, but the fix belongs upstream.
+- Vulnerabilities that only affect the dev toolchain (Vite, Vitest, esbuild
+  dev server) and never reach published artifacts. CI audits these
+  informationally but does not ship them to consumers.
+
+## Supply-chain integrity
+
+What we do so you can trust the bytes you install:
+
+- **No runtime dependencies.** `npm ls --omit=dev --omit=peer` is empty for the
+  published package — there is no transitive runtime tree to compromise.
+- **Trusted publishing via OIDC.** Releases are published from GitHub Actions
+  using npm's OIDC trusted publishing — there is **no long-lived `NPM_TOKEN`**
+  to leak. Each release carries an **npm provenance attestation** linking the
+  tarball to the exact workflow run and commit that built it.
+- **Pinned CI actions.** Every GitHub Action is pinned to a full commit SHA,
+  not a moving tag, so a compromised upstream tag cannot silently alter our
+  pipeline.
+- **Runtime dependency audit gate.** CI runs `npm audit --omit=dev
+  --audit-level=low` on every push and PR; a runtime advisory fails the build.
+
+Verify a published release yourself:
+
+```sh
+npm view voidframe-ui dist.integrity        # subresource integrity hash
+npm audit signatures                         # verify provenance + signatures
+```
+
+## Disclosure policy
+
+We follow coordinated disclosure: we ask that you give us a reasonable window
+to ship a fix before any public write-up. Once a patched version is released we
+will publish a GitHub Security Advisory (and an npm advisory where applicable)
+describing the issue, affected versions, and the fix.

--- a/docs/App.tsx
+++ b/docs/App.tsx
@@ -28,6 +28,7 @@ import { patterns, type Pattern } from "./patterns";
 import { componentHooks, getComponentsForHook } from "./hookMap";
 import { usageSnippets, LIVE_NON_ELEMENTS } from "./usageSnippets";
 import { SandboxButtons } from "./sandbox/SandboxButtons";
+import AiConsole from "./showcase/AiConsole";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -806,6 +807,14 @@ const items: NavItem[] = [
     render: () => <OverviewPage />,
     searchText: "overview intro",
   },
+  {
+    id: "showcase-ai-console",
+    title: "AI Console",
+    section: "Showcase",
+    render: () => <AiConsole />,
+    searchText:
+      "showcase ai console agent demo landing chat trace tool call plan agentstep agenttrace",
+  },
   ...guides.map((g) => ({
     id: `guide-${g.id}`,
     title: g.title,
@@ -919,6 +928,7 @@ for (const c of compatDocs) {
 
 type SectionName =
   | "Overview"
+  | "Showcase"
   | "Guides"
   | "Patterns"
   | "Components"
@@ -936,6 +946,7 @@ interface GroupedSection {
 function groupItems(list: NavItem[]): GroupedSection[] {
   const sections: SectionName[] = [
     "Overview",
+    "Showcase",
     "Guides",
     "Patterns",
     "Components",

--- a/docs/App.tsx
+++ b/docs/App.tsx
@@ -515,6 +515,162 @@ function A11yAuditPage() {
   );
 }
 
+// ── Trust / security posture page ────────────────────────────
+
+const CI_GATES: Array<{ label: string; detail: string }> = [
+  { label: "Typecheck", detail: "tsc across the whole tree, zero errors" },
+  { label: "Lint", detail: "voidframe component rules + CSS token discipline" },
+  { label: "Tests", detail: "full Vitest suite (jsdom) on every push & PR" },
+  { label: "Coverage", detail: "collected and tracked on main via Codecov" },
+  { label: "a11y", detail: "jest-axe assertions on a representative cross-section" },
+  { label: "SSR", detail: "render + hydration tests under Node, no DOM globals" },
+  { label: "Types", detail: "type-level tests (test/types) for public surface" },
+  { label: "Render audit", detail: "every docs playground evaluated through react-live" },
+  { label: "Bundle size", detail: "size-limit budgets enforced per entry point" },
+  { label: "Dist verify", detail: "all 23 entry points + .d.ts + CSS present in dist" },
+  { label: "Pack dry-run", detail: "npm pack --dry-run confirms the published file list" },
+];
+
+const BUNDLE_BUDGETS: Array<{ name: string; limit: string }> = [
+  { name: "Core (voidframe.es.js)", limit: "200 KB gz" },
+  { name: "Charts (charts.es.js)", limit: "42 KB gz" },
+  { name: "Core subpath (core.es.js)", limit: "25 KB gz" },
+  { name: "Primitives (primitives.es.js)", limit: "15 KB gz" },
+  { name: "Dev tools (dev.es.js)", limit: "10 KB gz" },
+  { name: "Stylesheet (voidframe.css)", limit: "50 KB gz" },
+];
+
+function TrustPage() {
+  return (
+    <div className="vf-docs__page">
+      <section className="vf-docs__block">
+        <Text>
+          Voidframe is built to be auditable. It ships with{" "}
+          <strong>zero runtime dependencies</strong> — every heavy capability
+          (charts, QR/barcode, flow diagrams, HTML sanitisation) is a peer
+          dependency you install and version yourself — and every release is
+          published from CI with cryptographic provenance. The claims below are
+          enforced by the pipeline on every commit, not aspirations.
+        </Text>
+        <div style={{ display: "flex", gap: 16, marginTop: 12, flexWrap: "wrap" }}>
+          <Stat label="Runtime deps" value="0" />
+          <Stat label="Tests" value="3,900+" />
+          <Stat label="Test files" value="330+" />
+          <Stat label="License" value="MIT" />
+        </div>
+      </section>
+
+      <hr className="vf-docs__divider" />
+
+      <section className="vf-docs__block">
+        <Text size="sm" upper spacing={2} color="var(--vf-text-2)">
+          Supply-chain integrity
+        </Text>
+        <ul style={{ paddingLeft: 20, lineHeight: 1.8 }}>
+          <li>
+            <strong>No runtime dependency tree.</strong> The published package
+            has an empty <code>dependencies</code> map — nothing transitive to
+            compromise.
+          </li>
+          <li>
+            <strong>OIDC trusted publishing.</strong> Releases are published from
+            GitHub Actions with no long-lived <code>NPM_TOKEN</code>; npm issues
+            a short-lived token per run.
+          </li>
+          <li>
+            <strong>Provenance attestations.</strong> Each tarball is linked to
+            the exact workflow run and commit that built it.
+          </li>
+          <li>
+            <strong>Pinned actions.</strong> Every GitHub Action is pinned to a
+            full commit SHA, so a hijacked upstream tag can't alter the pipeline.
+          </li>
+          <li>
+            <strong>Audit gate.</strong> CI runs{" "}
+            <code>npm audit --omit=dev --audit-level=low</code> on runtime
+            dependencies and fails on any advisory.
+          </li>
+        </ul>
+        <Text size="sm" color="var(--vf-text-3)">
+          Verify any published release yourself:
+        </Text>
+        <CodeBlock
+          language="shell"
+          code={`npm view voidframe-ui dist.integrity   # subresource integrity hash
+npm audit signatures                   # verify provenance + signatures`}
+        />
+      </section>
+
+      <hr className="vf-docs__divider" />
+
+      <section className="vf-docs__block">
+        <Text size="sm" upper spacing={2} color="var(--vf-text-2)">
+          CI gates (every push &amp; pull request)
+        </Text>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--vf-font-sm)" }}>
+          <tbody>
+            {CI_GATES.map((g) => (
+              <tr key={g.label} style={{ borderBottom: "1px solid var(--vf-border-0)" }}>
+                <td style={{ padding: "4px 8px", whiteSpace: "nowrap" }}>
+                  <Badge tone="success" size="sm">{g.label}</Badge>
+                </td>
+                <td style={{ padding: "4px 8px", color: "var(--vf-text-3)" }}>{g.detail}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <hr className="vf-docs__divider" />
+
+      <section className="vf-docs__block">
+        <Text size="sm" upper spacing={2} color="var(--vf-text-2)">
+          Bundle-size budgets (gzipped, enforced)
+        </Text>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--vf-font-sm)" }}>
+          <tbody>
+            {BUNDLE_BUDGETS.map((b) => (
+              <tr key={b.name} style={{ borderBottom: "1px solid var(--vf-border-0)" }}>
+                <td style={{ padding: "4px 8px" }}>{b.name}</td>
+                <td style={{ padding: "4px 8px", textAlign: "end", whiteSpace: "nowrap" }}>
+                  <Badge size="sm" variant="outline">{b.limit}</Badge>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <Text size="sm" color="var(--vf-text-3)">
+          The library is side-effect free apart from its stylesheet
+          (<code>sideEffects: ["*.css"]</code>), so unused components are
+          tree-shaken out of your build.
+        </Text>
+      </section>
+
+      <hr className="vf-docs__divider" />
+
+      <section className="vf-docs__block">
+        <Text size="sm" upper spacing={2} color="var(--vf-text-2)">
+          Reporting a vulnerability
+        </Text>
+        <Text>
+          Found a security issue? Please report it privately through GitHub
+          Security Advisories rather than a public issue. Full policy, supported
+          versions, and response targets are in{" "}
+          <a
+            href="https://github.com/DaxAvalon/voidframe-ui/security/advisories/new"
+            target="_blank"
+            rel="noreferrer"
+            style={{ color: "var(--vf-text-0)" }}
+          >
+            SECURITY.md
+          </a>
+          .
+        </Text>
+      </section>
+    </div>
+  );
+}
+
 function MigrationPage() {
   const guide = migrations[0];
   if (!guide) return <Text>No migration guides available yet.</Text>;
@@ -659,6 +815,14 @@ const items: NavItem[] = [
     section: "Guides",
     render: () => <A11yAuditPage />,
     searchText: "accessibility a11y audit wcag keyboard screen reader",
+  },
+  {
+    id: "security-trust",
+    title: "Security & Trust",
+    section: "Guides",
+    render: () => <TrustPage />,
+    searchText:
+      "security trust supply chain provenance oidc trusted publishing zero dependencies audit ci gates bundle size vulnerability disclosure",
   },
   {
     id: "migration-guide",

--- a/docs/App.tsx
+++ b/docs/App.tsx
@@ -27,6 +27,7 @@ import { categorize, CATEGORIES, type Category } from "./taxonomy";
 import { patterns, type Pattern } from "./patterns";
 import { componentHooks, getComponentsForHook } from "./hookMap";
 import { usageSnippets, LIVE_NON_ELEMENTS } from "./usageSnippets";
+import { SandboxButtons } from "./sandbox/SandboxButtons";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -250,6 +251,7 @@ function ComponentPage({ name, onNavigate }: { name: string; onNavigate?: (id: s
                 scope={playgroundScope}
                 paneHeight={260}
                 noInline={ex.noInline ?? /\brender\s*\(/.test(ex.code)}
+                actions={(code) => <SandboxButtons code={code} title={ex.title} />}
               />
             </section>
           ))
@@ -261,6 +263,7 @@ function ComponentPage({ name, onNavigate }: { name: string; onNavigate?: (id: s
             scope={playgroundScope}
             paneHeight={260}
             noInline={/\brender\s*\(/.test(autoCode)}
+            actions={(code) => <SandboxButtons code={code} title={name} />}
           />
         ) : (
           <Text size="sm" color="var(--vf-text-3)">
@@ -460,6 +463,7 @@ function PatternPage({ pattern }: { pattern: Pattern }) {
           scope={playgroundScope}
           paneHeight={400}
           noInline={/\brender\s*\(/.test(pattern.code)}
+          actions={(code) => <SandboxButtons code={code} title={pattern.title} />}
         />
       </div>
     </div>

--- a/docs/__tests__/aiConsole.test.tsx
+++ b/docs/__tests__/aiConsole.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithTheme } from "../../test/renderWithTheme";
+import AiConsole from "../showcase/AiConsole";
+
+describe("AI Console showcase", () => {
+  it("mounts the full composition without crashing", () => {
+    renderWithTheme(<AiConsole />);
+    // Header + transcript content from the assembled components.
+    expect(screen.getAllByText("deploy-bot").length).toBeGreaterThan(0);
+    expect(screen.getByText(/CI is red on main/)).toBeTruthy();
+  });
+
+  it("renders the agent trace steps and plan", () => {
+    renderWithTheme(<AiConsole />);
+    expect(screen.getByText("Inspect CI logs")).toBeTruthy();
+    expect(screen.getByText("Reproduce locally")).toBeTruthy();
+    expect(screen.getByText(/Open a PR with the fix/)).toBeTruthy();
+  });
+
+  it("renders the status bar metrics", () => {
+    renderWithTheme(<AiConsole />);
+    expect(screen.getByText("MODEL")).toBeTruthy();
+    // Appears in both the header badge and the status bar.
+    expect(screen.getAllByText("claude-opus-4").length).toBeGreaterThan(0);
+  });
+});

--- a/docs/__tests__/sandbox.test.ts
+++ b/docs/__tests__/sandbox.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import * as voidframe from "../../src";
+import * as charts from "../../src/charts";
+import { buildProject } from "../sandbox/buildProject";
+
+// A component that lives only in the charts subpath (not re-exported from the
+// main barrel), chosen dynamically so the test never drifts from the library.
+const chartOnlyName = Object.keys(charts).find(
+  (k) => !(k in voidframe)
+)!;
+
+describe("buildProject", () => {
+  it("emits a complete, runnable project scaffold", () => {
+    const { files, dependencies } = buildProject("<Button>Hi</Button>");
+    expect(Object.keys(files)).toEqual(
+      expect.arrayContaining([
+        "package.json",
+        "index.html",
+        "vite.config.ts",
+        "tsconfig.json",
+        "src/main.tsx",
+        "src/Example.tsx",
+      ])
+    );
+    expect(dependencies["voidframe-ui"]).toMatch(/^\^\d+\.\d+\.\d+/);
+    expect(dependencies.react).toBeTruthy();
+    expect(dependencies["react-dom"]).toBeTruthy();
+    // main.tsx wires the provider and stylesheet.
+    expect(files["src/main.tsx"]).toContain("voidframe-ui/styles.css");
+    expect(files["src/main.tsx"]).toContain("VoidframeProvider");
+  });
+
+  it("infers named imports from voidframe-ui and react", () => {
+    const { files } = buildProject(
+      `<div>{(() => { const [n] = useState(0); return n; })()}<Button>Go</Button></div>`
+    );
+    const example = files["src/Example.tsx"];
+    expect(example).toContain(`import { Button } from "voidframe-ui";`);
+    expect(example).toContain(`import { useState } from "react";`);
+  });
+
+  it("imports chart-only components from the charts subpath and adds d3 peers", () => {
+    const { files, dependencies } = buildProject(`<${chartOnlyName} data={[]} />`);
+    expect(files["src/Example.tsx"]).toContain(
+      `import { ${chartOnlyName} } from "voidframe-ui/charts";`
+    );
+    expect(dependencies["d3-array"]).toBeTruthy();
+    expect(dependencies["d3-scale"]).toBeTruthy();
+  });
+
+  it("does not pull d3 peers for a non-chart snippet", () => {
+    const { dependencies } = buildProject("<Button>Hi</Button>");
+    expect(dependencies["d3-array"]).toBeUndefined();
+    expect(dependencies["@xyflow/react"]).toBeUndefined();
+  });
+
+  it("wraps a render()-style (noInline) snippet so it returns the node", () => {
+    const code = `const x = 1;\nrender(<Badge>{x}</Badge>);`;
+    const { files } = buildProject(code, { noInline: true });
+    const example = files["src/Example.tsx"];
+    expect(example).toContain("const render = (node");
+    expect(example).toContain("return <>{__node}</>");
+    expect(example).toContain(`import { Badge } from "voidframe-ui";`);
+  });
+
+  it("aliases scope-only names to their real export", () => {
+    const { files } = buildProject("<TokenCounter />");
+    expect(files["src/Example.tsx"]).toContain(
+      "ChatTokenCounter as TokenCounter"
+    );
+  });
+});

--- a/docs/guides.tsx
+++ b/docs/guides.tsx
@@ -132,15 +132,20 @@ function ThemingGuide() {
       </Section>
       <Section title="Built-in themes">
         <Text>
-          Four bundled themes ship out of the box. Pick one via the{" "}
-          <code>theme</code> prop on the provider.
+          Six bundled themes ship out of the box. <code>soft</code> and{" "}
+          <code>soft-light</code> are the rounded, lower-contrast pair — they
+          set non-zero radius tokens, so corners round across the whole UI
+          while keeping the monospace identity. Pick one via the{" "}
+          <code>themeName</code> prop on the provider.
         </Text>
         <CodeBlock>{`import { VoidframeProvider } from "voidframe-ui";
 
-<VoidframeProvider theme="dark">      {/* default */}
-<VoidframeProvider theme="light">
-<VoidframeProvider theme="midnight">
-<VoidframeProvider theme="grey">`}</CodeBlock>
+<VoidframeProvider themeName="dark">      {/* default */}
+<VoidframeProvider themeName="light">
+<VoidframeProvider themeName="midnight">
+<VoidframeProvider themeName="grey">
+<VoidframeProvider themeName="soft">       {/* rounded dark */}
+<VoidframeProvider themeName="soft-light"> {/* rounded light */}`}</CodeBlock>
       </Section>
       <Section title="Overriding tokens">
         <Text>

--- a/docs/guides.tsx
+++ b/docs/guides.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { Text } from "../src";
 import { Playground } from "../src/dev";
 import { playgroundScope } from "./scope";
+import { SandboxButtons } from "./sandbox/SandboxButtons";
 
 export interface Guide {
   id: string;
@@ -94,6 +95,7 @@ createRoot(document.getElementById("root")!).render(
     <Button variant="solid">Ship it</Button>
   </div>
 </Card>`}
+          actions={(code) => <SandboxButtons code={code} title="Hello, voidframe-ui" />}
         />
       </Section>
       <Section title="Next">

--- a/docs/guides.tsx
+++ b/docs/guides.tsx
@@ -365,6 +365,65 @@ const unsub = subscribeWarnings((entry) => {
   );
 }
 
+function TailwindGuide() {
+  return (
+    <>
+      <Section title="What the preset gives you">
+        <Text>
+          Voidframe ships a Tailwind preset that maps its{" "}
+          <code>--vf-*</code> design tokens onto Tailwind's theme scales. You
+          get utilities like <code>bg-vf-bg-1</code>,{" "}
+          <code>text-vf-text-0</code>, <code>border-vf-border-2</code>,{" "}
+          <code>p-vf-4</code>, and <code>font-vf-mono</code> — and because each
+          one resolves to a CSS custom property, they re-theme automatically
+          whenever <code>VoidframeProvider</code> swaps the active theme.
+        </Text>
+      </Section>
+      <Section title="Install">
+        <Text>
+          Add the preset to your Tailwind config. It only extends the theme, so
+          it composes with your existing config and other presets.
+        </Text>
+        <CodeBlock>{`// tailwind.config.js
+module.exports = {
+  presets: [require("voidframe-ui/tailwind")],
+  content: ["./src/**/*.{ts,tsx}"],
+};`}</CodeBlock>
+        <Text>
+          ESM configs work too:{" "}
+          <code>import vf from "voidframe-ui/tailwind"</code> then{" "}
+          <code>presets: [vf]</code>.
+        </Text>
+      </Section>
+      <Section title="Available utilities">
+        <CodeBlock>{`<div class="bg-vf-bg-1 text-vf-text-0 border border-vf-border-2 p-vf-4">
+  <h2 class="font-vf-mono text-vf-xl tracking-vf-heading">Status</h2>
+  <span class="text-vf-green bg-vf-green-10 px-vf-2">OK</span>
+</div>`}</CodeBlock>
+        <Text>
+          Scales: colors (<code>vf-bg-*</code>, <code>vf-text-*</code>,{" "}
+          <code>vf-border-*</code>, accents with <code>5/10/20/40/60</code>{" "}
+          opacity steps, and <code>vf-success|danger|warning|info</code>),
+          spacing (<code>vf-1</code>…<code>vf-12</code>), font family/size,
+          line-height, letter-spacing, border radius, border width, and{" "}
+          <code>vf-sm</code>…<code>vf-xxl</code> breakpoints.
+        </Text>
+      </Section>
+      <Section title="How re-theming works">
+        <Text>
+          The preset's color, spacing, and typography values are{" "}
+          <code>var(--vf-*)</code> references — not hard-coded hex. Mount{" "}
+          <code>VoidframeProvider</code> (or apply the theme's CSS variables)
+          and every Tailwind utility above follows the active theme with no
+          rebuild. Breakpoints are the one exception: CSS media queries can't
+          read custom properties, so <code>vf-*</code> screens are emitted as
+          literal pixels from the default theme.
+        </Text>
+      </Section>
+    </>
+  );
+}
+
 // ── Index ─────────────────────────────────────────────────────
 
 export const guides: Guide[] = [
@@ -397,5 +456,11 @@ export const guides: Guide[] = [
     title: "Dev tools",
     subtitle: "DevPanel, ErrorBoundary, render profiler, misuse warnings.",
     render: () => <DevToolsGuide />,
+  },
+  {
+    id: "tailwind",
+    title: "Tailwind preset",
+    subtitle: "Use voidframe's --vf-* tokens as Tailwind utilities.",
+    render: () => <TailwindGuide />,
   },
 ];

--- a/docs/sandbox/SandboxButtons.tsx
+++ b/docs/sandbox/SandboxButtons.tsx
@@ -1,0 +1,36 @@
+// Docs-only toolbar dropped into each Playground's header via its `actions`
+// slot. Receives the current (possibly edited) snippet and opens it as a full
+// project in StackBlitz or CodeSandbox.
+
+import { openInStackBlitz, openInCodeSandbox } from "./index";
+
+export interface SandboxButtonsProps {
+  code: string;
+  title?: string;
+}
+
+export function SandboxButtons({ code, title }: SandboxButtonsProps) {
+  // Derive noInline from the live snippet so it tracks edits in the editor,
+  // matching how a `render(...)` call is detected elsewhere in the docs.
+  const opts = { noInline: /\brender\s*\(/.test(code), title };
+  return (
+    <>
+      <button
+        type="button"
+        className="vf-playground__reset"
+        title="Open this example in StackBlitz"
+        onClick={() => openInStackBlitz(code, opts)}
+      >
+        StackBlitz ↗
+      </button>
+      <button
+        type="button"
+        className="vf-playground__reset"
+        title="Open this example in CodeSandbox"
+        onClick={() => openInCodeSandbox(code, opts)}
+      >
+        CodeSandbox ↗
+      </button>
+    </>
+  );
+}

--- a/docs/sandbox/buildProject.ts
+++ b/docs/sandbox/buildProject.ts
@@ -1,0 +1,235 @@
+// Turns a docs playground snippet into a complete, runnable Vite + React + TS
+// project that can be opened in StackBlitz or CodeSandbox. The same project
+// shape feeds both providers; only the final "open" transport differs.
+//
+// The hard part is reproducing the docs playground's scope (where every
+// voidframe export and a handful of React hooks are bare identifiers) as real
+// ES module imports. We infer the imports by scanning the snippet for
+// identifiers that match known export names — the export sets are derived from
+// the actual source barrels, so they never drift from what the library ships.
+
+import * as voidframe from "../../src";
+import * as charts from "../../src/charts";
+import pkg from "../../package.json";
+
+const VF_NAMES = new Set(Object.keys(voidframe));
+// Names that live only in the charts subpath (the main barrel does not
+// re-export them), so they must be imported from "voidframe-ui/charts".
+const CHART_NAMES = new Set(
+  Object.keys(charts).filter((k) => !VF_NAMES.has(k))
+);
+
+const REACT_HOOKS = new Set([
+  "useState", "useEffect", "useMemo", "useCallback", "useRef", "useReducer",
+  "useContext", "useLayoutEffect", "useId", "useTransition", "useDeferredValue",
+  "useImperativeHandle", "useSyncExternalStore", "useInsertionEffect",
+]);
+
+// Identifiers the docs scope exposes under a different name than the real
+// export (see docs/scope.ts). Imported real-name-as-alias so the snippet still
+// resolves.
+const ALIASES: Record<string, string> = { TokenCounter: "ChatTokenCounter" };
+
+const peers = (pkg.peerDependencies ?? {}) as Record<string, string>;
+const VF_VERSION = `^${pkg.version}`;
+
+function pickPeers(names: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const n of names) if (peers[n]) out[n] = peers[n];
+  return out;
+}
+
+function uniqueIdentifiers(code: string): Set<string> {
+  const ids = new Set<string>();
+  const re = /[A-Za-z_$][A-Za-z0-9_$]*/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(code))) ids.add(m[0]);
+  return ids;
+}
+
+export interface BuildProjectOptions {
+  title?: string;
+  /** Matches the docs Playground prop: snippet calls `render(...)` itself. */
+  noInline?: boolean;
+}
+
+export interface SandboxProject {
+  title: string;
+  description: string;
+  /** Path → file contents, rooted at the project directory. */
+  files: Record<string, string>;
+  dependencies: Record<string, string>;
+}
+
+function buildImports(ids: Set<string>): string {
+  const reactHooks: string[] = [];
+  const vfNamed: string[] = [];
+  const vfAliased: string[] = [];
+  const chartNamed: string[] = [];
+  let usesReactNamespace = false;
+
+  for (const id of ids) {
+    if (id === "React") usesReactNamespace = true;
+    else if (REACT_HOOKS.has(id)) reactHooks.push(id);
+    else if (ALIASES[id]) vfAliased.push(`${ALIASES[id]} as ${id}`);
+    else if (CHART_NAMES.has(id)) chartNamed.push(id);
+    else if (VF_NAMES.has(id)) vfNamed.push(id);
+  }
+
+  const lines: string[] = [];
+  if (usesReactNamespace) lines.push(`import * as React from "react";`);
+  if (reactHooks.length)
+    lines.push(`import { ${reactHooks.sort().join(", ")} } from "react";`);
+  const vfAll = [...vfNamed.sort(), ...vfAliased.sort()];
+  if (vfAll.length)
+    lines.push(`import { ${vfAll.join(", ")} } from "voidframe-ui";`);
+  if (chartNamed.length)
+    lines.push(
+      `import { ${chartNamed.sort().join(", ")} } from "voidframe-ui/charts";`
+    );
+  return lines.join("\n");
+}
+
+function buildExample(code: string, noInline: boolean, imports: string): string {
+  if (noInline) {
+    // The snippet declares helpers and calls render(<X/>). Provide a local
+    // `render` that captures the node, then return it — mirroring how
+    // react-live evaluates noInline snippets.
+    return `${imports}
+
+export default function Example() {
+  let __node: React.ReactNode = null;
+  const render = (node: React.ReactNode) => {
+    __node = node;
+  };
+${code
+  .split("\n")
+  .map((l) => (l ? `  ${l}` : l))
+  .join("\n")}
+  return <>{__node}</>;
+}
+`;
+  }
+  return `${imports}
+
+export default function Example() {
+  return (
+    ${code.trim()}
+  );
+}
+`;
+}
+
+export function buildProject(
+  code: string,
+  { title = "Voidframe example", noInline = false }: BuildProjectOptions = {}
+): SandboxProject {
+  const ids = uniqueIdentifiers(code);
+  // React's namespace is referenced by the generated Example wrapper.
+  ids.add("React");
+  const imports = buildImports(ids);
+
+  const chartsUsed = [...ids].some((id) => CHART_NAMES.has(id));
+  const flowUsed = [...ids].some((id) => /Flow/.test(id) && /^[A-Z]/.test(id));
+
+  const dependencies: Record<string, string> = {
+    "voidframe-ui": VF_VERSION,
+    ...pickPeers(["react", "react-dom"]),
+    // Small, broadly-used peers — cheap to include so QR/barcode/markdown
+    // snippets always run.
+    ...pickPeers(["dompurify", "jsbarcode", "qrcode-generator"]),
+  };
+  if (chartsUsed) {
+    Object.assign(
+      dependencies,
+      pickPeers([
+        "d3-array", "d3-force", "d3-geo", "d3-hierarchy", "d3-sankey",
+        "d3-scale", "d3-shape", "d3-time", "topojson-client",
+      ])
+    );
+  }
+  if (flowUsed) Object.assign(dependencies, pickPeers(["@xyflow/react"]));
+
+  const example = buildExample(code, noInline, imports);
+
+  const files: Record<string, string> = {
+    "package.json": JSON.stringify(
+      {
+        name: "voidframe-example",
+        private: true,
+        version: "0.0.0",
+        type: "module",
+        scripts: {
+          dev: "vite",
+          build: "vite build",
+          preview: "vite preview",
+        },
+        dependencies,
+        devDependencies: {
+          "@types/react": "^18.3.0",
+          "@types/react-dom": "^18.3.0",
+          "@vitejs/plugin-react": "^4.3.0",
+          typescript: "^5.5.0",
+          vite: "^5.4.0",
+        },
+      },
+      null,
+      2
+    ),
+    "index.html": `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${title}</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+`,
+    "vite.config.ts": `import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({ plugins: [react()] });
+`,
+    "tsconfig.json": JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ESNext",
+          useDefineForClassFields: true,
+          lib: ["DOM", "DOM.Iterable", "ESNext"],
+          module: "ESNext",
+          skipLibCheck: true,
+          moduleResolution: "bundler",
+          jsx: "react-jsx",
+          strict: true,
+          noEmit: true,
+        },
+        include: ["src"],
+      },
+      null,
+      2
+    ),
+    "src/main.tsx": `import { createRoot } from "react-dom/client";
+import { VoidframeProvider } from "voidframe-ui";
+import "voidframe-ui/styles.css";
+import Example from "./Example";
+
+createRoot(document.getElementById("root")!).render(
+  <VoidframeProvider>
+    <Example />
+  </VoidframeProvider>
+);
+`,
+    "src/Example.tsx": example,
+  };
+
+  return {
+    title,
+    description: "Voidframe UI example — opened from the docs playground.",
+    files,
+    dependencies,
+  };
+}

--- a/docs/sandbox/index.ts
+++ b/docs/sandbox/index.ts
@@ -1,0 +1,64 @@
+// Opens a generated SandboxProject in StackBlitz or CodeSandbox. Both use a
+// form POST to the provider's "create from files" endpoint, so no provider SDK
+// is required — only CodeSandbox needs its parameters payload compressed.
+
+import { compressToBase64 } from "lz-string";
+import { buildProject, type BuildProjectOptions } from "./buildProject";
+
+function submitForm(action: string, fields: Record<string, string>): void {
+  const form = document.createElement("form");
+  form.method = "POST";
+  form.action = action;
+  form.target = "_blank";
+  form.style.display = "none";
+  for (const [name, value] of Object.entries(fields)) {
+    const input = document.createElement("input");
+    input.type = "hidden";
+    input.name = name;
+    input.value = value;
+    form.appendChild(input);
+  }
+  document.body.appendChild(form);
+  form.submit();
+  form.remove();
+}
+
+export function openInStackBlitz(code: string, opts: BuildProjectOptions = {}): void {
+  const project = buildProject(code, opts);
+  const fields: Record<string, string> = {
+    "project[title]": project.title,
+    "project[description]": project.description,
+    // WebContainer template; StackBlitz reads package.json from the files and
+    // auto-detects Vite to boot `npm run dev`.
+    "project[template]": "node",
+  };
+  for (const [path, content] of Object.entries(project.files)) {
+    fields[`project[files][${path}]`] = content;
+  }
+  submitForm("https://stackblitz.com/run", fields);
+}
+
+// Mirrors codesandbox/lib/api/define: LZ-compress the JSON payload to a
+// URL-safe base64 string.
+function encodeParameters(parameters: unknown): string {
+  return compressToBase64(JSON.stringify(parameters))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export function openInCodeSandbox(code: string, opts: BuildProjectOptions = {}): void {
+  const project = buildProject(code, opts);
+  const files: Record<string, { content: string }> = {};
+  for (const [path, content] of Object.entries(project.files)) {
+    files[path] = { content };
+  }
+  const parameters = encodeParameters({ files });
+  submitForm("https://codesandbox.io/api/v1/sandboxes/define", {
+    parameters,
+    query: "file=/src/Example.tsx",
+  });
+}
+
+export { buildProject } from "./buildProject";
+export type { SandboxProject, BuildProjectOptions } from "./buildProject";

--- a/docs/showcase/AiConsole.tsx
+++ b/docs/showcase/AiConsole.tsx
@@ -1,0 +1,257 @@
+// AI-console landing demo — a full-page product screen assembled entirely from
+// shipped voidframe-ui components (no bespoke widgets). It shows the chat / AI
+// tier (Message, AgentTrace, AgentStep, ToolCall, PlanDisplay) composed inside
+// the AppShell layout with a status bar and an inspector panel — the kind of
+// "agent console" voidframe is built for.
+
+import type { ReactNode } from "react";
+import {
+  AppShell,
+  Text,
+  Badge,
+  Button,
+  Card,
+  Stat,
+  Input,
+  Message,
+  AgentTrace,
+  AgentStep,
+  ToolCall,
+  PlanDisplay,
+  StatusBar,
+} from "../../src";
+
+function NavItem({ label, active }: { label: string; active?: boolean }) {
+  return (
+    <button
+      type="button"
+      style={{
+        display: "block",
+        width: "100%",
+        textAlign: "start",
+        padding: "6px 10px",
+        background: active ? "var(--vf-bg-3)" : "transparent",
+        border: "1px solid",
+        borderColor: active ? "var(--vf-border-2)" : "transparent",
+        color: active ? "var(--vf-text-0)" : "var(--vf-text-2)",
+        font: "inherit",
+        fontSize: "var(--vf-font-sm)",
+        cursor: "pointer",
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <Text size="sm" upper spacing={2} color="var(--vf-text-2)">
+        {title}
+      </Text>
+      {children}
+    </div>
+  );
+}
+
+const sidebar = (
+  <div style={{ display: "flex", flexDirection: "column", gap: 16, padding: 12 }}>
+    <Text size="lg" upper spacing={3} color="var(--vf-text-0)">
+      ▲ VOIDFRAME
+    </Text>
+    <Section title="Workspace">
+      <NavItem label="Sessions" active />
+      <NavItem label="Agents" />
+      <NavItem label="Tools" />
+      <NavItem label="Datasets" />
+    </Section>
+    <Section title="Recent runs">
+      <NavItem label="deploy-bot · #4821" />
+      <NavItem label="triage-agent · #4820" />
+      <NavItem label="codegen · #4817" />
+    </Section>
+  </div>
+);
+
+const header = (
+  <div
+    style={{
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      padding: "8px 16px",
+      width: "100%",
+    }}
+  >
+    <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+      <Text size="md" color="var(--vf-text-0)" style={{ fontWeight: 600 }}>
+        deploy-bot
+      </Text>
+      <Badge size="sm" variant="outline">
+        claude-opus-4
+      </Badge>
+      <Badge size="sm" tone="success">
+        running
+      </Badge>
+    </div>
+    <div style={{ display: "flex", gap: 8 }}>
+      <Button size="sm" variant="ghost">
+        Share
+      </Button>
+      <Button size="sm" variant="solid">
+        New run
+      </Button>
+    </div>
+  </div>
+);
+
+const rightPanel = (
+  <div style={{ display: "flex", flexDirection: "column", gap: 16, padding: 12 }}>
+    <Section title="Run metrics">
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+        <Stat label="Tokens" value="48.2k" change={12} changeDirection="up" />
+        <Stat label="Cost" value="$0.19" />
+        <Stat label="Latency" value="2.4s" change={8} changeDirection="down" tone="success" />
+        <Stat label="Steps" value="4" />
+      </div>
+    </Section>
+    <Section title="Context">
+      <Card style={{ padding: 12, display: "flex", flexDirection: "column", gap: 6 }}>
+        <Text size="sm" color="var(--vf-text-1)">repo: voidframe-ui</Text>
+        <Text size="sm" color="var(--vf-text-1)">branch: main</Text>
+        <Text size="sm" color="var(--vf-text-1)">12 files in scope</Text>
+      </Card>
+    </Section>
+    <Section title="Guardrails">
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+        <Badge size="sm" tone="success">read-only fs</Badge>
+        <Badge size="sm" tone="warning">network: allowlist</Badge>
+        <Badge size="sm">max 8 steps</Badge>
+      </div>
+    </Section>
+  </div>
+);
+
+const footer = (
+  <StatusBar
+    items={[
+      { label: "STATUS", value: "running", color: "var(--vf-success)" },
+      { label: "MODEL", value: "claude-opus-4" },
+      { label: "TOKENS", value: "48,210" },
+      { label: "COST", value: "$0.19" },
+      { label: "ELAPSED", value: "00:02.4" },
+    ]}
+  />
+);
+
+const planSteps = [
+  { id: "1", title: "Read CI failure logs", status: "done" as const },
+  { id: "2", title: "Locate the failing assertion", status: "done" as const },
+  { id: "3", title: "Patch the date util and re-run tests", status: "active" as const },
+  { id: "4", title: "Open a PR with the fix", status: "pending" as const },
+];
+
+export default function AiConsole() {
+  return (
+    <AppShell
+      header={header}
+      sidebar={sidebar}
+      rightPanel={rightPanel}
+      footer={footer}
+      sidebarWidth={240}
+      rightPanelWidth={280}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 16,
+          padding: 16,
+          maxWidth: 860,
+        }}
+      >
+        <Message
+          role="user"
+          author={{ name: "you" }}
+          content="CI is red on main — the date utils test is failing. Find the cause and open a fix."
+        />
+        <Message
+          role="assistant"
+          author={{ name: "deploy-bot" }}
+          content="On it. I'll pull the failing logs, isolate the assertion, patch the util, and verify before opening a PR."
+        />
+
+        <AgentTrace
+          status="running"
+          duration={2400}
+          tokens={{ input: 31200, output: 17010, total: 48210 }}
+          cost="$0.19"
+          steps={
+            <>
+              <AgentStep
+                number={1}
+                title="Inspect CI logs"
+                status="complete"
+                duration={420}
+                toolCalls={
+                  <ToolCall
+                    name="ci.get_logs"
+                    status="complete"
+                    args={{ run: 4821, job: "test" }}
+                    result={{ failing: 1, suite: "utils/date" }}
+                    duration={310}
+                  />
+                }
+                output="One failing assertion in addDays() around month boundaries."
+              />
+              <AgentStep
+                number={2}
+                title="Reproduce locally"
+                status="complete"
+                duration={680}
+                toolCalls={
+                  <ToolCall
+                    name="shell.run"
+                    status="complete"
+                    args={{ cmd: "npm test -- date" }}
+                    result={{ failed: 1, passed: 218 }}
+                    duration={650}
+                  />
+                }
+              />
+              <AgentStep
+                number={3}
+                title="Patch and re-test"
+                status="running"
+                toolCalls={
+                  <ToolCall
+                    name="fs.apply_patch"
+                    status="running"
+                    args={{ file: "src/utils/date.ts" }}
+                  />
+                }
+              />
+            </>
+          }
+        />
+
+        <Card style={{ padding: 16 }}>
+          <Text size="sm" upper spacing={2} color="var(--vf-text-2)" style={{ marginBottom: 8 }}>
+            Plan
+          </Text>
+          <PlanDisplay steps={planSteps} />
+        </Card>
+
+        <div style={{ display: "flex", gap: 8 }}>
+          <Input
+            placeholder="Send a follow-up instruction…"
+            aria-label="Send a follow-up instruction"
+            style={{ flex: 1 }}
+          />
+          <Button variant="solid">Send</Button>
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -120,10 +120,16 @@
       "require": "./dist/compat-shadcn.cjs.js"
     },
     "./theme-script.js": "./theme-script.js",
+    "./tailwind": {
+      "types": "./tailwind/preset.d.ts",
+      "import": "./tailwind/preset.mjs",
+      "require": "./tailwind/preset.cjs"
+    },
     "./package.json": "./package.json"
   },
   "files": [
     "dist",
+    "tailwind",
     "theme-script.js",
     "README.md",
     "LICENSE",

--- a/scripts/__tests__/tailwind-preset.test.ts
+++ b/scripts/__tests__/tailwind-preset.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+// The preset is the shipped CommonJS source of truth.
+import presetRaw from "../../tailwind/preset.cjs";
+import { tokensToCssVars } from "../../src/themes";
+import { defaultTokens } from "../../src/tokens";
+
+const preset = presetRaw as {
+  theme: { extend: Record<string, unknown> };
+};
+
+// Every `var(--vf-*)` reference anywhere in the preset object.
+function collectVarRefs(node: unknown, out: Set<string>): void {
+  if (typeof node === "string") {
+    const re = /var\((--vf-[a-z0-9-]+)\)/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(node))) out.add(m[1]);
+  } else if (node && typeof node === "object") {
+    for (const v of Object.values(node)) collectVarRefs(v, out);
+  }
+}
+
+const referenced = new Set<string>();
+collectVarRefs(preset.theme.extend, referenced);
+
+// The canonical set of variables the runtime actually emits.
+const emitted = new Set(Object.keys(tokensToCssVars(defaultTokens)));
+
+// Variables that map cleanly onto a Tailwind scale and therefore MUST be
+// surfaced by the preset. Excludes vars with no idiomatic Tailwind home
+// (the transition shorthand, heading-case) and breakpoints (emitted as
+// literal px screens, asserted separately).
+function isMappable(v: string): boolean {
+  if (/^--vf-(bg|text)-\d+$/.test(v)) return true;
+  if (/^--vf-border-\d+$/.test(v)) return true; // border colors
+  if (/^--vf-border-width-\d+$/.test(v)) return true; // border widths
+  if (/^--vf-(green|red|amber|blue|purple|cyan|rose)(-\d+)?$/.test(v)) return true;
+  if (/^--vf-(success|danger|warning|info)$/.test(v)) return true;
+  if (/^--vf-sp-\d+$/.test(v)) return true;
+  if (/^--vf-font-(xxs|xs|sm|md|lg|xl|xxl|3xl)$/.test(v)) return true;
+  if (/^--vf-font-(family|mono|sans|display)$/.test(v)) return true;
+  if (/^--vf-radius(-\d+)?$/.test(v)) return true;
+  if (/^--vf-(letter-spacing|label-spacing|heading-tracking|line-height)$/.test(v))
+    return true;
+  return false;
+}
+
+describe("tailwind preset", () => {
+  it("only references variables the runtime actually emits", () => {
+    const stale = [...referenced].filter((v) => !emitted.has(v));
+    expect(stale).toEqual([]);
+  });
+
+  it("surfaces every mappable token (guards against drift)", () => {
+    const missing = [...emitted].filter(
+      (v) => isMappable(v) && !referenced.has(v)
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("keeps breakpoint screens in sync with the default theme", () => {
+    const screens = preset.theme.extend.screens as Record<string, string>;
+    expect(screens["vf-sm"]).toBe(`${defaultTokens.bpSm}px`);
+    expect(screens["vf-md"]).toBe(`${defaultTokens.bpMd}px`);
+    expect(screens["vf-lg"]).toBe(`${defaultTokens.bpLg}px`);
+    expect(screens["vf-xl"]).toBe(`${defaultTokens.bpXl}px`);
+    expect(screens["vf-xxl"]).toBe(`${defaultTokens.bpXxl}px`);
+  });
+
+  it("exposes the expected Tailwind theme scales", () => {
+    const e = preset.theme.extend;
+    for (const key of [
+      "colors", "spacing", "fontFamily", "fontSize", "lineHeight",
+      "letterSpacing", "borderRadius", "borderWidth", "screens",
+    ]) {
+      expect(e[key], `missing theme.extend.${key}`).toBeTruthy();
+    }
+  });
+});

--- a/src/css/components/dev.css
+++ b/src/css/components/dev.css
@@ -24,6 +24,11 @@
   letter-spacing: 0.06em;
   color: var(--vf-text-0);
 }
+.vf-playground__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--vf-sp-1);
+}
 .vf-playground__reset {
   padding: var(--vf-sp-1) var(--vf-sp-2);
   background: transparent;

--- a/src/dev/Playground.tsx
+++ b/src/dev/Playground.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState, type CSSProperties } from "react";
+import { useCallback, useState, type CSSProperties, type ReactNode } from "react";
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from "react-live";
 import { cx } from "../utils/cx";
 
@@ -17,6 +17,12 @@ export interface PlaygroundProps {
   title?: string;
   /** When true, the snippet is treated as an expression; otherwise it's a full block ending with `render(...)`. */
   noInline?: boolean;
+  /**
+   * Optional toolbar slot rendered in the header, to the left of Reset.
+   * Receives the current (possibly edited) source so callers can act on
+   * exactly what the user sees — e.g. "open in sandbox" links.
+   */
+  actions?: (code: string) => ReactNode;
 }
 
 export function Playground({
@@ -26,6 +32,7 @@ export function Playground({
   paneHeight = 220,
   title = "Playground",
   noInline = false,
+  actions,
 }: PlaygroundProps) {
   const [code, setCode] = useState(initialCode);
   const reset = useCallback(() => setCode(initialCode), [initialCode]);
@@ -38,13 +45,16 @@ export function Playground({
     <div className={cx("vf-playground", className)}>
       <div className="vf-playground__head">
         <span className="vf-playground__title">{title}</span>
-        <button
-          type="button"
-          className="vf-playground__reset"
-          onClick={reset}
-        >
-          Reset
-        </button>
+        <div className="vf-playground__actions">
+          {actions?.(code)}
+          <button
+            type="button"
+            className="vf-playground__reset"
+            onClick={reset}
+          >
+            Reset
+          </button>
+        </div>
       </div>
       <LiveProvider code={code} scope={scope} noInline={noInline}>
         <div className="vf-playground__body">

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,8 @@ export {
   lightTheme,
   midnightTheme,
   greyTheme,
+  softTheme,
+  softLightTheme,
   tokensToCssVars,
   THEME_NAMES,
 } from "./themes";

--- a/src/provider/ThemeScope.tsx
+++ b/src/provider/ThemeScope.tsx
@@ -25,6 +25,8 @@ import {
   lightTheme,
   midnightTheme,
   greyTheme,
+  softTheme,
+  softLightTheme,
 } from "../themes";
 import {
   useTokens,
@@ -40,6 +42,8 @@ const BUILTIN_THEMES: Record<BuiltInThemeName, VoidframeTokens> = {
   light: lightTheme,
   midnight: midnightTheme,
   grey: greyTheme,
+  soft: softTheme,
+  "soft-light": softLightTheme,
 };
 
 export interface ThemeScopeProps

--- a/src/provider/VoidframeProvider.tsx
+++ b/src/provider/VoidframeProvider.tsx
@@ -22,6 +22,8 @@ import {
   lightTheme,
   midnightTheme,
   greyTheme,
+  softTheme,
+  softLightTheme,
   tokensToCssVars,
   type BuiltInThemeName,
 } from "../themes";
@@ -126,6 +128,8 @@ const BUILTIN_THEMES: Record<BuiltInThemeName, VoidframeTokens> = {
   light: lightTheme,
   midnight: midnightTheme,
   grey: greyTheme,
+  soft: softTheme,
+  "soft-light": softLightTheme,
 };
 
 function resolveSystemScheme(): "dark" | "light" {

--- a/src/themes/__tests__/softThemes.test.ts
+++ b/src/themes/__tests__/softThemes.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { defaultTokens } from "../../tokens";
+import {
+  THEME_NAMES,
+  softTheme,
+  softLightTheme,
+  tokensToCssVars,
+} from "../index";
+
+describe("soft / soft-light themes", () => {
+  it("are registered as built-in theme names", () => {
+    expect(THEME_NAMES).toContain("soft");
+    expect(THEME_NAMES).toContain("soft-light");
+  });
+
+  it("are complete token sets (every contract key present)", () => {
+    for (const theme of [softTheme, softLightTheme]) {
+      for (const key of Object.keys(defaultTokens)) {
+        expect(theme).toHaveProperty(key);
+      }
+    }
+  });
+
+  it("round the corners (the soft signature)", () => {
+    expect(softTheme.radius).toBe(6);
+    expect(softLightTheme.radius).toBe(6);
+    expect(softTheme.radius).toBeGreaterThan(defaultTokens.radius);
+  });
+
+  it("emit radius with a px unit so non-zero radii apply", () => {
+    // Regression guard for removing `radius` from UNITLESS_KEYS.
+    expect(tokensToCssVars(softTheme)["--vf-radius"]).toBe("6px");
+    expect(tokensToCssVars(defaultTokens)["--vf-radius"]).toBe("0px");
+  });
+
+  it("keep accent opacity ramps consistent with their base hue", () => {
+    expect(softTheme.green20.startsWith(softTheme.green)).toBe(true);
+    expect(softLightTheme.blue40.startsWith(softLightTheme.blue)).toBe(true);
+  });
+});

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -11,8 +11,17 @@ export { darkTheme } from "./dark";
 export { lightTheme } from "./light";
 export { midnightTheme } from "./midnight";
 export { greyTheme } from "./grey";
+export { softTheme } from "./soft";
+export { softLightTheme } from "./soft-light";
 
-export const THEME_NAMES = ["dark", "light", "midnight", "grey"] as const;
+export const THEME_NAMES = [
+  "dark",
+  "light",
+  "midnight",
+  "grey",
+  "soft",
+  "soft-light",
+] as const;
 export type BuiltInThemeName = (typeof THEME_NAMES)[number];
 
 /** Emit `--vf-*` CSS custom properties from a partial or full token set. */
@@ -34,7 +43,6 @@ export function tokensToCssVars(
 
 const UNITLESS_KEYS = new Set<keyof VoidframeTokens>([
   "lineHeight",
-  "radius",
 ]);
 
 function camelToKebab(s: string): string {

--- a/src/themes/soft-light.ts
+++ b/src/themes/soft-light.ts
@@ -1,0 +1,50 @@
+// Phase 18 — soft-light theme.
+//
+// The rounded, low-contrast counterpart to `soft` for light environments: a
+// warm "paper" surface ramp instead of glaring white, gentle borders, and the
+// same rounded corners (radius 6 / 4 / 10). Accents are the darker light-theme
+// values so they stay legible on a pale background.
+
+import { createTheme, type VoidframeTokens } from "../tokens";
+
+export const softLightTheme: VoidframeTokens = createTheme({
+  bg0: "#faf9f6",
+  bg1: "#f1f0ec",
+  bg2: "#e9e8e3",
+  bg3: "#e0dfd9",
+  bg4: "#d3d2ca",
+  bg5: "#c4c3ba",
+  border0: "#e0dfd9",
+  border1: "#cfcec6",
+  border2: "#b3b2a9",
+  border3: "#8d8c83",
+  border4: "#66655d",
+  text0: "#1c1b18",
+  text1: "#3a3934",
+  text2: "#5c5b54",
+  text3: "#7c7b73",
+  text4: "#9b9a91",
+  text5: "#b9b8af",
+  green: "#0f7f38",
+  red: "#b91c1c",
+  amber: "#854d0e",
+  blue: "#1d4ed8",
+  purple: "#6d28d9",
+  cyan: "#0e7490",
+  rose: "#be123c",
+  green5: "#0f7f380d", green10: "#0f7f381a", green20: "#0f7f3833", green40: "#0f7f3866", green60: "#0f7f3899",
+  red5: "#b91c1c0d", red10: "#b91c1c1a", red20: "#b91c1c33", red40: "#b91c1c66", red60: "#b91c1c99",
+  amber5: "#854d0e0d", amber10: "#854d0e1a", amber20: "#854d0e33", amber40: "#854d0e66", amber60: "#854d0e99",
+  blue5: "#1d4ed80d", blue10: "#1d4ed81a", blue20: "#1d4ed833", blue40: "#1d4ed866", blue60: "#1d4ed899",
+  purple5: "#6d28d90d", purple10: "#6d28d91a", purple20: "#6d28d933", purple40: "#6d28d966", purple60: "#6d28d999",
+  cyan5: "#0e74900d", cyan10: "#0e74901a", cyan20: "#0e749033", cyan40: "#0e749066", cyan60: "#0e749099",
+  rose5: "#be123c0d", rose10: "#be123c1a", rose20: "#be123c33", rose40: "#be123c66", rose60: "#be123c99",
+  success: "#0f7f38",
+  danger: "#b91c1c",
+  warning: "#854d0e",
+  info: "#1d4ed8",
+  // The soft signature: rounded corners.
+  radius: 6,
+  radius1: 4,
+  radius2: 10,
+});

--- a/src/themes/soft.ts
+++ b/src/themes/soft.ts
@@ -1,0 +1,51 @@
+// Phase 18 — soft theme.
+//
+// A rounded, lower-contrast take on the dark theme. Surfaces step up in soft
+// charcoals rather than pure black, borders are gentle, and corners are
+// rounded (radius 6 / 4 / 10) — the deliberate opt-out of the brutalist
+// zero-radius default for product UIs that want a calmer feel while keeping
+// the monospace identity. Accents reuse the soft pastel ramp.
+
+import { createTheme, type VoidframeTokens } from "../tokens";
+
+export const softTheme: VoidframeTokens = createTheme({
+  bg0: "#121214",
+  bg1: "#17171a",
+  bg2: "#1c1c20",
+  bg3: "#222227",
+  bg4: "#29292f",
+  bg5: "#313138",
+  border0: "#222227",
+  border1: "#2b2b31",
+  border2: "#38383f",
+  border3: "#47474f",
+  border4: "#5a5a63",
+  text0: "#f3f3f6",
+  text1: "#cdcdd4",
+  text2: "#9696a0",
+  text3: "#6a6a73",
+  text4: "#45454c",
+  text5: "#2b2b31",
+  green: "#6ee7a8",
+  red: "#fb7185",
+  amber: "#f1c96b",
+  blue: "#8fb8f0",
+  purple: "#c4a3ff",
+  cyan: "#7fe8f3",
+  rose: "#ff95b6",
+  green5: "#6ee7a80d", green10: "#6ee7a81a", green20: "#6ee7a833", green40: "#6ee7a866", green60: "#6ee7a899",
+  red5: "#fb71850d", red10: "#fb71851a", red20: "#fb718533", red40: "#fb718566", red60: "#fb718599",
+  amber5: "#f1c96b0d", amber10: "#f1c96b1a", amber20: "#f1c96b33", amber40: "#f1c96b66", amber60: "#f1c96b99",
+  blue5: "#8fb8f00d", blue10: "#8fb8f01a", blue20: "#8fb8f033", blue40: "#8fb8f066", blue60: "#8fb8f099",
+  purple5: "#c4a3ff0d", purple10: "#c4a3ff1a", purple20: "#c4a3ff33", purple40: "#c4a3ff66", purple60: "#c4a3ff99",
+  cyan5: "#7fe8f30d", cyan10: "#7fe8f31a", cyan20: "#7fe8f333", cyan40: "#7fe8f366", cyan60: "#7fe8f399",
+  rose5: "#ff95b60d", rose10: "#ff95b61a", rose20: "#ff95b633", rose40: "#ff95b666", rose60: "#ff95b699",
+  success: "#6ee7a8",
+  danger: "#fb7185",
+  warning: "#f1c96b",
+  info: "#8fb8f0",
+  // The soft signature: rounded corners.
+  radius: 6,
+  radius1: 4,
+  radius2: 10,
+});

--- a/tailwind/preset.cjs
+++ b/tailwind/preset.cjs
@@ -1,0 +1,120 @@
+// Voidframe UI — Tailwind CSS preset.
+//
+// Maps voidframe's `--vf-*` design tokens onto Tailwind's theme scales so you
+// can use voidframe's tokens as first-class Tailwind utilities — and have them
+// re-theme automatically when VoidframeProvider swaps the active theme, since
+// every value resolves to a CSS custom property at runtime.
+//
+//   // tailwind.config.js
+//   module.exports = { presets: [require("voidframe-ui/tailwind")] };
+//
+//   <div class="bg-vf-bg-1 text-vf-text-0 border border-vf-border-2 p-vf-4 font-vf-mono" />
+//
+// Color/spacing/typography utilities reference `var(--vf-*)`, so they follow
+// the active theme. Breakpoints are emitted as literal pixel values (CSS media
+// queries cannot read custom properties) taken from the default theme.
+
+/** Accent ramp: DEFAULT plus the 5/10/20/40/60 opacity variants. */
+function accent(name) {
+  return {
+    DEFAULT: `var(--vf-${name})`,
+    5: `var(--vf-${name}-5)`,
+    10: `var(--vf-${name}-10)`,
+    20: `var(--vf-${name}-20)`,
+    40: `var(--vf-${name}-40)`,
+    60: `var(--vf-${name}-60)`,
+  };
+}
+
+/** Numbered scale: { [from..to]: var(--vf-<prefix>-<n>) }. */
+function scale(prefix, from, to) {
+  const out = {};
+  for (let i = from; i <= to; i++) out[i] = `var(--vf-${prefix}-${i})`;
+  return out;
+}
+
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        vf: {
+          bg: scale("bg", 0, 5),
+          border: scale("border", 0, 4),
+          text: scale("text", 0, 5),
+          green: accent("green"),
+          red: accent("red"),
+          amber: accent("amber"),
+          blue: accent("blue"),
+          purple: accent("purple"),
+          cyan: accent("cyan"),
+          rose: accent("rose"),
+          success: "var(--vf-success)",
+          danger: "var(--vf-danger)",
+          warning: "var(--vf-warning)",
+          info: "var(--vf-info)",
+        },
+      },
+      spacing: {
+        "vf-1": "var(--vf-sp-1)",
+        "vf-2": "var(--vf-sp-2)",
+        "vf-3": "var(--vf-sp-3)",
+        "vf-4": "var(--vf-sp-4)",
+        "vf-5": "var(--vf-sp-5)",
+        "vf-6": "var(--vf-sp-6)",
+        "vf-7": "var(--vf-sp-7)",
+        "vf-8": "var(--vf-sp-8)",
+        "vf-9": "var(--vf-sp-9)",
+        "vf-10": "var(--vf-sp-10)",
+        "vf-11": "var(--vf-sp-11)",
+        "vf-12": "var(--vf-sp-12)",
+      },
+      fontFamily: {
+        vf: "var(--vf-font-family)",
+        "vf-mono": "var(--vf-font-mono)",
+        "vf-sans": "var(--vf-font-sans)",
+        "vf-display": "var(--vf-font-display)",
+      },
+      fontSize: {
+        "vf-xxs": "var(--vf-font-xxs)",
+        "vf-xs": "var(--vf-font-xs)",
+        "vf-sm": "var(--vf-font-sm)",
+        "vf-md": "var(--vf-font-md)",
+        "vf-lg": "var(--vf-font-lg)",
+        "vf-xl": "var(--vf-font-xl)",
+        "vf-xxl": "var(--vf-font-xxl)",
+        "vf-3xl": "var(--vf-font-3xl)",
+      },
+      lineHeight: {
+        vf: "var(--vf-line-height)",
+      },
+      letterSpacing: {
+        vf: "var(--vf-letter-spacing)",
+        "vf-label": "var(--vf-label-spacing)",
+        "vf-heading": "var(--vf-heading-tracking)",
+      },
+      borderRadius: {
+        vf: "var(--vf-radius)",
+        "vf-1": "var(--vf-radius-1)",
+        "vf-2": "var(--vf-radius-2)",
+      },
+      borderWidth: {
+        "vf-0": "var(--vf-border-width-0)",
+        "vf-1": "var(--vf-border-width-1)",
+        "vf-2": "var(--vf-border-width-2)",
+        "vf-3": "var(--vf-border-width-3)",
+        "vf-4": "var(--vf-border-width-4)",
+      },
+      transitionProperty: {
+        vf: "all",
+      },
+      screens: {
+        // Literal px from the default theme — media queries can't read vars.
+        "vf-sm": "640px",
+        "vf-md": "768px",
+        "vf-lg": "1024px",
+        "vf-xl": "1280px",
+        "vf-xxl": "1536px",
+      },
+    },
+  },
+};

--- a/tailwind/preset.d.ts
+++ b/tailwind/preset.d.ts
@@ -1,0 +1,23 @@
+// Type surface for the Tailwind preset. Kept structural (not dependent on
+// `tailwindcss` types) so consumers without Tailwind installed still typecheck.
+type TokenScale = Record<string, string | Record<string, string>>;
+
+interface VoidframePreset {
+  theme: {
+    extend: {
+      colors: Record<string, TokenScale | string>;
+      spacing: Record<string, string>;
+      fontFamily: Record<string, string>;
+      fontSize: Record<string, string>;
+      lineHeight: Record<string, string>;
+      letterSpacing: Record<string, string>;
+      borderRadius: Record<string, string>;
+      borderWidth: Record<string, string>;
+      transitionProperty: Record<string, string>;
+      screens: Record<string, string>;
+    };
+  };
+}
+
+declare const preset: VoidframePreset;
+export default preset;

--- a/tailwind/preset.mjs
+++ b/tailwind/preset.mjs
@@ -1,0 +1,6 @@
+// ESM entry for the Tailwind preset. Re-exports the single CommonJS source of
+// truth so `import preset from "voidframe-ui/tailwind"` and
+// `require("voidframe-ui/tailwind")` yield the same object.
+import preset from "./preset.cjs";
+
+export default preset;

--- a/tools/cli/__tests__/init.test.ts
+++ b/tools/cli/__tests__/init.test.ts
@@ -47,6 +47,53 @@ describe("init command", () => {
     expect(main).toContain("voidframe-ui/styles.css");
   });
 
+  it("scaffolds the Next.js (App Router) template with --template next", async () => {
+    const code = await initCommand({
+      dir,
+      force: true,
+      template: "next",
+      log: silentLog,
+    });
+    expect(code).toBe(0);
+    expect(existsSync(join(dir, "package.json"))).toBe(true);
+    expect(existsSync(join(dir, "next.config.mjs"))).toBe(true);
+    expect(existsSync(join(dir, "app", "layout.tsx"))).toBe(true);
+    expect(existsSync(join(dir, "app", "page.tsx"))).toBe(true);
+    // No Vite SPA entrypoints in a Next project.
+    expect(existsSync(join(dir, "src", "main.tsx"))).toBe(false);
+  });
+
+  it("the Next template wires next + voidframe deps and SSR theme handling", async () => {
+    await initCommand({ dir, force: true, template: "next", log: silentLog });
+    const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf-8"));
+    expect(pkg.dependencies).toHaveProperty("next");
+    expect(pkg.dependencies).toHaveProperty("voidframe-ui");
+    const layout = readFileSync(join(dir, "app", "layout.tsx"), "utf-8");
+    expect(layout).toContain("voidframe-ui/styles.css");
+    expect(layout).toContain("VoidframeProvider");
+    // Pre-hydration theme script + suppressed hydration warning.
+    expect(layout).toContain("data-vf-theme");
+    expect(layout).toContain("suppressHydrationWarning");
+  });
+
+  it("rejects an unknown template", async () => {
+    const errors: string[] = [];
+    const code = await initCommand({
+      dir,
+      force: true,
+      template: "svelte",
+      log: { log: () => {}, error: (m: string) => errors.push(m) },
+    });
+    expect(code).toBe(1);
+    expect(errors[0]).toMatch(/Unknown template/);
+  });
+
+  it("defaults to the Vite (app) template when none is given", async () => {
+    await initCommand({ dir, force: true, log: silentLog });
+    expect(existsSync(join(dir, "src", "main.tsx"))).toBe(true);
+    expect(existsSync(join(dir, "app", "layout.tsx"))).toBe(false);
+  });
+
   it("refuses to overwrite a non-empty directory without --force", async () => {
     const { writeFileSync } = await import("node:fs");
     writeFileSync(join(dir, "existing.txt"), "hi");

--- a/tools/cli/bin/voidframe.mjs
+++ b/tools/cli/bin/voidframe.mjs
@@ -35,10 +35,19 @@ export function buildProgram({ exit = true } = {}) {
 
   program
     .command("init <directory>")
-    .description("Scaffold a new Vite + React project pre-wired with voidframe.")
+    .description("Scaffold a new React project pre-wired with voidframe.")
     .option("--force", "Overwrite the target directory if it already exists.")
+    .option(
+      "--template <name>",
+      "Project template: app (Vite SPA) or next (Next.js App Router).",
+      "app"
+    )
     .action(async (dir, opts) => {
-      const code = await initCommand({ dir, force: Boolean(opts.force) });
+      const code = await initCommand({
+        dir,
+        force: Boolean(opts.force),
+        template: opts.template,
+      });
       done(code);
     });
 

--- a/tools/cli/commands/_init-shared.mjs
+++ b/tools/cli/commands/_init-shared.mjs
@@ -9,7 +9,15 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-export const TEMPLATE_DIR = resolve(__dirname, "..", "templates", "app");
+export const TEMPLATES_ROOT = resolve(__dirname, "..", "templates");
+/** Default (Vite) template. Kept as a named export for back-compat. */
+export const TEMPLATE_DIR = resolve(TEMPLATES_ROOT, "app");
+
+/** Templates the scaffolder can produce, in display order. */
+export const TEMPLATES = {
+  app: "Vite + React + TypeScript SPA",
+  next: "Next.js (App Router) + TypeScript",
+};
 
 async function pathExists(p) {
   try {
@@ -40,13 +48,26 @@ async function copyTemplate(src, dest) {
  * @param {object} opts
  * @param {string} opts.dir Target directory (relative paths resolved against cwd).
  * @param {boolean} [opts.force] Overwrite an existing non-empty target.
+ * @param {string} [opts.template] Template name (see TEMPLATES). Default "app".
  * @param {Console} [opts.log] Logger; defaults to global console.
  */
-export async function scaffold({ dir, force = false, log = console } = {}) {
+export async function scaffold({
+  dir,
+  force = false,
+  template = "app",
+  log = console,
+} = {}) {
   if (!dir) {
     log.error("✖ Missing target directory.");
     return 1;
   }
+  if (!Object.prototype.hasOwnProperty.call(TEMPLATES, template)) {
+    log.error(
+      `✖ Unknown template "${template}". Available: ${Object.keys(TEMPLATES).join(", ")}.`
+    );
+    return 1;
+  }
+  const templateDir = resolve(TEMPLATES_ROOT, template);
   const target = resolve(dir);
   const exists = await pathExists(target);
   if (exists && !force) {
@@ -58,7 +79,7 @@ export async function scaffold({ dir, force = false, log = console } = {}) {
       return 1;
     }
   }
-  await copyTemplate(TEMPLATE_DIR, target);
+  await copyTemplate(templateDir, target);
   // Rewrite package.json name.
   const pkgPath = join(target, "package.json");
   const pkgRaw = await readFile(pkgPath, "utf-8");
@@ -69,7 +90,7 @@ export async function scaffold({ dir, force = false, log = console } = {}) {
     .replace(/[^a-z0-9_-]/gi, "-")
     .toLowerCase();
   await writeFile(pkgPath, JSON.stringify(pkg, null, 2) + "\n", "utf-8");
-  log.log(`✔ Scaffolded voidframe app at ${target}`);
+  log.log(`✔ Scaffolded voidframe ${template} app at ${target}`);
   log.log(`  Next steps:`);
   log.log(`    cd ${dir}`);
   log.log(`    npm install`);

--- a/tools/cli/templates/next/app/globals.css
+++ b/tools/cli/templates/next/app/globals.css
@@ -1,0 +1,13 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+  /* Default dark surface so the first paint matches before hydration.
+     Switch to a light theme? Update this to match your default theme. */
+  background: #050505;
+}

--- a/tools/cli/templates/next/app/layout.tsx
+++ b/tools/cli/templates/next/app/layout.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+import type { Metadata } from "next";
+import { VoidframeProvider } from "voidframe-ui";
+import "voidframe-ui/styles.css";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Voidframe App",
+  description: "A Next.js app pre-wired with voidframe-ui.",
+};
+
+// Pre-hydration theme script. Mirrors the `voidframe-theme` localStorage value
+// (or the OS preference) onto <html data-vf-theme> before first paint so
+// server-rendered pages don't flash the wrong theme. Keep the key in sync with
+// useThemePersistence({ key: "voidframe-theme" }). This is the App Router
+// placement of the shipped voidframe-ui/theme-script.js.
+const themeScript = `(function(){try{var k="voidframe-theme",t=localStorage.getItem(k);if(!t||t==="system"){t=window.matchMedia&&window.matchMedia("(prefers-color-scheme: light)").matches?"light":"dark";}document.documentElement.setAttribute("data-vf-theme",t);}catch(e){}})();`;
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+      </head>
+      <body>
+        <VoidframeProvider>{children}</VoidframeProvider>
+      </body>
+    </html>
+  );
+}

--- a/tools/cli/templates/next/app/page.tsx
+++ b/tools/cli/templates/next/app/page.tsx
@@ -1,0 +1,26 @@
+import { Text, Button, Card } from "voidframe-ui";
+
+export default function Home() {
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        padding: 24,
+        display: "grid",
+        placeItems: "center",
+      }}
+    >
+      <Card style={{ padding: 24, minWidth: 360 }}>
+        <Text size="xl" upper spacing={3} color="var(--vf-text-0)">
+          Voidframe
+        </Text>
+        <Text size="sm" color="var(--vf-text-3)">
+          Your Next.js app is running. Edit app/page.tsx to begin.
+        </Text>
+        <div style={{ marginTop: 16 }}>
+          <Button variant="solid">Get started</Button>
+        </div>
+      </Card>
+    </main>
+  );
+}

--- a/tools/cli/templates/next/next-env.d.ts
+++ b/tools/cli/templates/next/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited.
+// See https://nextjs.org/docs/app/api-reference/config/typescript for details.

--- a/tools/cli/templates/next/next.config.mjs
+++ b/tools/cli/templates/next/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/tools/cli/templates/next/package.json
+++ b/tools/cli/templates/next/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "voidframe-next-app",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^14.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "voidframe-ui": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/tools/cli/templates/next/tsconfig.json
+++ b/tools/cli/templates/next/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tools/create-voidframe-app/README.md
+++ b/tools/create-voidframe-app/README.md
@@ -1,13 +1,18 @@
 # create-voidframe-app
 
-Scaffold a new Vite + React + TypeScript project pre-wired with [voidframe-ui](https://npmjs.com/package/voidframe-ui)'s `VoidframeProvider`, stylesheet, and a starter page.
+Scaffold a new React + TypeScript project pre-wired with [voidframe-ui](https://npmjs.com/package/voidframe-ui)'s `VoidframeProvider`, stylesheet, and a starter page. Choose a **Vite SPA** or a **Next.js (App Router)** project.
 
 ## Usage
 
 ```bash
+# Vite SPA (default)
 npm create voidframe-app@latest my-app
-# or
-npx create-voidframe-app my-app
+
+# Next.js App Router
+npm create voidframe-app@latest my-app --template next
+
+# or via npx
+npx create-voidframe-app my-app --template next
 ```
 
 Then:
@@ -20,18 +25,28 @@ npm run dev
 
 ## Options
 
+- `--template` / `-t` `<name>` — template to scaffold: `app` (Vite SPA, default) or `next` (Next.js App Router).
 - `--force` / `-f` — overwrite a non-empty target directory.
 - `--help` / `-h` — show usage.
 
-## What you get
+## Templates
+
+### `app` — Vite SPA
 
 - Vite 5 + React 18 + TypeScript 5
-- `voidframe-ui` (latest) installed as a runtime dependency
-- `<VoidframeProvider themeName="system">` mounted at the React root
-- `voidframe-ui/styles.css` imported once
-- Pre-hydration `theme-script.js` injected to prevent dark↔light flash
-- A starter `App.tsx` with `<AppShell>` + `<Sidebar>` + a few demo widgets
+- `voidframe-ui` installed as a runtime dependency
+- `voidframe-ui/styles.css` imported once in `src/main.tsx`
+- `<VoidframeProvider>` mounted at the React root in `src/App.tsx`
+- A starter page using `Card`, `Text`, and `Button`
+
+### `next` — Next.js App Router
+
+- Next.js 14 (App Router) + React 18 + TypeScript 5
+- `voidframe-ui/styles.css` imported in `app/layout.tsx`
+- `<VoidframeProvider>` wraps the app in the root layout
+- A **pre-hydration theme script** inlined in `<head>` (the App Router placement of `voidframe-ui/theme-script.js`) that mirrors the saved theme onto `<html data-vf-theme>` before paint — no dark↔light flash. `<html>` carries `suppressHydrationWarning` because the script mutates the attribute before hydration.
+- A server-component starter `app/page.tsx` rendering voidframe components
 
 ## Internals
 
-This package is a thin wrapper around `voidframe init`. The scaffolding logic lives in `tools/cli/commands/init.mjs` of the [voidframe-ui](https://github.com/DaxAvalon/voidframe-ui) monorepo so both entry points stay in sync.
+This package is a thin wrapper around `voidframe init`. The scaffolding logic and templates live under `tools/cli/` of the [voidframe-ui](https://github.com/DaxAvalon/voidframe-ui) monorepo (`commands/_init-shared.mjs`, `templates/<name>/`) so both entry points stay in sync.

--- a/tools/create-voidframe-app/bin/cli.mjs
+++ b/tools/create-voidframe-app/bin/cli.mjs
@@ -10,28 +10,33 @@
 import { scaffold } from "../../cli/commands/_init-shared.mjs";
 
 function parseArgs(argv) {
-  const args = { dir: null, force: false };
+  const args = { dir: null, force: false, template: "app" };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--force" || arg === "-f") args.force = true;
     else if (arg === "--help" || arg === "-h") args.help = true;
+    else if (arg === "--template" || arg === "-t") args.template = argv[++i];
+    else if (arg.startsWith("--template=")) args.template = arg.slice(11);
     else if (!args.dir && !arg.startsWith("-")) args.dir = arg;
   }
   return args;
 }
 
 function printHelp() {
-  console.log(`Usage: npm create voidframe-app <directory> [--force]
+  console.log(`Usage: npm create voidframe-app <directory> [--template <name>] [--force]
 
-Scaffolds a new Vite + React + TypeScript project pre-wired with
-voidframe-ui's provider, stylesheet, and a starter page.
+Scaffolds a new React + TypeScript project pre-wired with voidframe-ui's
+provider, stylesheet, and a starter page.
 
 Options:
-  --force, -f    Overwrite an existing non-empty directory.
-  --help, -h     Show this message.
+  --template, -t <name>  Template to use: app (Vite SPA, default) or
+                         next (Next.js App Router).
+  --force, -f            Overwrite an existing non-empty directory.
+  --help, -h             Show this message.
 
 Examples:
   npm create voidframe-app@latest my-app
+  npm create voidframe-app@latest my-app --template next
   npx create-voidframe-app my-app
 `);
 }
@@ -45,6 +50,7 @@ async function main() {
   const code = await scaffold({
     dir: args.dir,
     force: args.force,
+    template: args.template,
     log: console,
   });
   process.exit(code ?? 0);

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -1,0 +1,76 @@
+# voidframe-mcp
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server that exposes
+[voidframe-ui](https://npmjs.com/package/voidframe-ui)'s component, hook, and
+utility catalog to AI agents — so Claude, Cursor, and other MCP clients can look
+up exact component names, props, types, and signatures instead of guessing.
+
+It's a **zero-dependency** stdio server built over the same structured data that
+powers the docs site and `llms.txt`.
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `list_components` | List components, filterable by `kind` (`element`, `layout`, `primitive`, `provider`, `subcomponent`, `compat`) or a search `query`. |
+| `get_component` | Full docs for one component: kind, source file, description, and every prop (type, default, required, description). |
+| `list_hooks` / `get_hook` | List hooks or fetch one hook's signature + description. |
+| `list_utils` / `get_util` | List utilities or fetch one utility's signature + description. |
+| `search` | Search components, hooks, and utilities at once. |
+
+## Configuration
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "voidframe": {
+      "command": "npx",
+      "args": ["-y", "voidframe-mcp"]
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "voidframe": { "command": "npx", "args": ["-y", "voidframe-mcp"] }
+  }
+}
+```
+
+### Claude Code
+
+```bash
+claude mcp add voidframe -- npx -y voidframe-mcp
+```
+
+## Data source
+
+The catalog is resolved in this order:
+
+1. `VOIDFRAME_MCP_DATA` — a directory containing `components.json`, `hooks.json`,
+   and `utils.json` (point this at a specific version if you like).
+2. A `data/` snapshot bundled in the published package.
+3. The monorepo's `docs/public/api/` (used when running from a checkout).
+
+To refresh the bundled snapshot before publishing the standalone package, run
+`npm run docs:extract-props && npm run docs:generate-llms` at the repo root,
+then `node tools/mcp/scripts/sync-data.mjs`.
+
+## Running directly
+
+```bash
+npx voidframe-mcp        # speaks MCP over stdio
+```
+
+The server implements JSON-RPC 2.0 with `initialize`, `tools/list`,
+`tools/call`, and `ping` — no SDK required.

--- a/tools/mcp/__tests__/catalog.test.ts
+++ b/tools/mcp/__tests__/catalog.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  loadCatalog,
+  searchList,
+  shortDescription,
+  componentSummary,
+} from "../lib/catalog.mjs";
+
+const catalog = loadCatalog();
+
+describe("catalog", () => {
+  it("loads components, hooks, and utils with name indexes", () => {
+    expect(catalog.components.length).toBeGreaterThan(100);
+    expect(catalog.hooks.length).toBeGreaterThan(10);
+    expect(catalog.utils.length).toBeGreaterThan(10);
+    expect(catalog.byName.component.get("AccessibleIcon")).toBeTruthy();
+  });
+
+  it("shortDescription collapses to the first sentence/line", () => {
+    expect(shortDescription("First line.\nSecond line.")).toBe("First line.");
+    expect(shortDescription("One sentence. Two sentence.")).toBe("One sentence.");
+    expect(shortDescription("")).toBe("");
+  });
+
+  it("searchList ranks exact and prefix name matches first", () => {
+    const results = searchList(catalog.components, "button", 10);
+    expect(results.length).toBeGreaterThan(0);
+    // An exact "Button" (if present) or a Button* prefix should lead.
+    expect(results[0].name.toLowerCase()).toContain("button");
+  });
+
+  it("searchList with no query returns a name-sorted slice", () => {
+    const results = searchList(catalog.components, "", 5);
+    expect(results).toHaveLength(5);
+    const names = results.map((r) => r.name);
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it("componentSummary omits the props array", () => {
+    const c = catalog.byName.component.get("AccessibleIcon")!;
+    const summary = componentSummary(c);
+    expect(summary).toHaveProperty("kind");
+    expect(summary).not.toHaveProperty("props");
+  });
+});

--- a/tools/mcp/__tests__/server.test.ts
+++ b/tools/mcp/__tests__/server.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { PassThrough } from "node:stream";
+import { loadCatalog } from "../lib/catalog.mjs";
+import { createHandler, runStdio } from "../lib/server.mjs";
+
+const catalog = loadCatalog();
+const handle = createHandler(catalog);
+
+describe("MCP protocol handler", () => {
+  it("initialize echoes a supported protocol and advertises tools", () => {
+    const res: any = handle({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-06-18" },
+    });
+    expect(res.result.protocolVersion).toBe("2025-06-18");
+    expect(res.result.capabilities.tools).toBeTruthy();
+    expect(res.result.serverInfo.name).toBe("voidframe-mcp");
+  });
+
+  it("initialize falls back to a default for an unknown protocol", () => {
+    const res: any = handle({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "1999-01-01" },
+    });
+    expect(res.result.protocolVersion).toBe("2024-11-05");
+  });
+
+  it("returns null (no reply) for the initialized notification", () => {
+    expect(handle({ jsonrpc: "2.0", method: "notifications/initialized" })).toBeNull();
+  });
+
+  it("tools/list returns the tool definitions", () => {
+    const res: any = handle({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+    expect(res.result.tools.map((t: any) => t.name)).toContain("get_component");
+  });
+
+  it("tools/call returns text content with the tool result", () => {
+    const res: any = handle({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "get_component", arguments: { name: "AccessibleIcon" } },
+    });
+    expect(res.result.isError).toBe(false);
+    const payload = JSON.parse(res.result.content[0].text);
+    expect(payload.name).toBe("AccessibleIcon");
+  });
+
+  it("tools/call flags isError for an unknown component", () => {
+    const res: any = handle({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: { name: "get_component", arguments: { name: "Nope" } },
+    });
+    expect(res.result.isError).toBe(true);
+  });
+
+  it("unknown method yields a -32601 error", () => {
+    const res: any = handle({ jsonrpc: "2.0", id: 5, method: "no/such" });
+    expect(res.error.code).toBe(-32601);
+  });
+
+  it("round-trips newline-delimited JSON over stdio streams", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    runStdio({ input, output, catalog });
+
+    const lines: string[] = [];
+    output.setEncoding("utf8");
+    output.on("data", (chunk: string) => {
+      for (const l of chunk.split("\n")) if (l.trim()) lines.push(l);
+    });
+
+    input.write(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }) + "\n");
+    // Notifications produce no output line.
+    input.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n");
+    input.write(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "list_hooks", arguments: { limit: 1 } },
+      }) + "\n"
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(lines.length).toBe(2); // only the two requests with ids reply
+    const second = JSON.parse(lines[1]);
+    expect(second.id).toBe(2);
+    expect(JSON.parse(second.result.content[0].text).count).toBe(1);
+  });
+});

--- a/tools/mcp/__tests__/tools.test.ts
+++ b/tools/mcp/__tests__/tools.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { loadCatalog } from "../lib/catalog.mjs";
+import { TOOL_DEFINITIONS, runTool } from "../lib/tools.mjs";
+
+const catalog = loadCatalog();
+
+describe("tools", () => {
+  it("every tool definition has a name, description, and object schema", () => {
+    for (const t of TOOL_DEFINITIONS) {
+      expect(t.name).toBeTruthy();
+      expect(t.description.length).toBeGreaterThan(10);
+      expect(t.inputSchema.type).toBe("object");
+    }
+  });
+
+  it("list_components filters by kind", () => {
+    const res = runTool("list_components", { kind: "primitive", limit: 100 }, catalog);
+    expect(res.count).toBeGreaterThan(0);
+    expect(res.components.every((c: any) => c.kind === "primitive")).toBe(true);
+  });
+
+  it("get_component returns full props for a known component", () => {
+    const res = runTool("get_component", { name: "AccessibleIcon" }, catalog);
+    expect(res.name).toBe("AccessibleIcon");
+    expect(Array.isArray(res.props)).toBe(true);
+  });
+
+  it("get_component returns a helpful error for an unknown name", () => {
+    const res = runTool("get_component", { name: "Nope" }, catalog);
+    expect(res.error).toMatch(/No component named/);
+  });
+
+  it("get_hook and get_util resolve known names", () => {
+    const hookName = catalog.hooks[0].name;
+    const utilName = catalog.utils[0].name;
+    expect(runTool("get_hook", { name: hookName }, catalog).name).toBe(hookName);
+    expect(runTool("get_util", { name: utilName }, catalog).name).toBe(utilName);
+  });
+
+  it("search spans all three categories", () => {
+    const res = runTool("search", { query: "use", limit: 5 }, catalog);
+    expect(res).toHaveProperty("components");
+    expect(res).toHaveProperty("hooks");
+    expect(res).toHaveProperty("utils");
+  });
+
+  it("throws on an unknown tool", () => {
+    expect(() => runTool("frobnicate", {}, catalog)).toThrow(/Unknown tool/);
+  });
+});

--- a/tools/mcp/bin/voidframe-mcp.mjs
+++ b/tools/mcp/bin/voidframe-mcp.mjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+// voidframe-mcp — Model Context Protocol server exposing voidframe-ui's
+// component, hook, and utility catalog to AI agents (Claude Desktop, Cursor,
+// etc.) over stdio.
+
+import { runStdio } from "../lib/server.mjs";
+
+runStdio();

--- a/tools/mcp/lib/catalog.mjs
+++ b/tools/mcp/lib/catalog.mjs
@@ -1,0 +1,112 @@
+// Data layer for the voidframe MCP server. Loads the structured
+// component / hook / utility catalog (the same JSON the docs site and
+// llms.txt are generated from) and provides pure search/lookup helpers.
+//
+// Zero dependencies — just node:fs. The transport (lib/server.mjs) and the
+// tool definitions (lib/tools.mjs) build on these pure functions, which keeps
+// everything unit-testable without spinning up stdio.
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Data directory resolution, in order:
+//   1. VOIDFRAME_MCP_DATA env override
+//   2. a co-located `data/` snapshot bundled into a published package
+//   3. the committed structured data in the monorepo (in-repo / dev)
+function resolveDataDir() {
+  if (process.env.VOIDFRAME_MCP_DATA) return process.env.VOIDFRAME_MCP_DATA;
+  const bundled = resolve(__dirname, "..", "data");
+  if (existsSync(resolve(bundled, "components.json"))) return bundled;
+  return resolve(__dirname, "..", "..", "..", "docs", "public", "api");
+}
+
+export const DEFAULT_DATA_DIR = resolveDataDir();
+
+function readJson(dir, file) {
+  return JSON.parse(readFileSync(resolve(dir, file), "utf8"));
+}
+
+/**
+ * Load and index the catalog from a data directory.
+ * @param {string} [dataDir]
+ */
+export function loadCatalog(dataDir = DEFAULT_DATA_DIR) {
+  const components = readJson(dataDir, "components.json");
+  const hooks = readJson(dataDir, "hooks.json");
+  const utils = readJson(dataDir, "utils.json");
+
+  const index = (list) => new Map(list.map((e) => [e.name, e]));
+
+  return {
+    dataDir,
+    components,
+    hooks,
+    utils,
+    byName: {
+      component: index(components),
+      hook: index(hooks),
+      util: index(utils),
+    },
+  };
+}
+
+/** First sentence / line of a (possibly multi-line) description. */
+export function shortDescription(desc) {
+  if (!desc) return "";
+  const firstLine = String(desc).split("\n")[0].trim();
+  const dot = firstLine.indexOf(". ");
+  return dot > 0 ? firstLine.slice(0, dot + 1) : firstLine;
+}
+
+function scoreMatch(entry, q) {
+  const name = entry.name.toLowerCase();
+  if (name === q) return 100;
+  if (name.startsWith(q)) return 80;
+  if (name.includes(q)) return 60;
+  const haystack = `${entry.description ?? ""} ${entry.signature ?? ""}`.toLowerCase();
+  if (haystack.includes(q)) return 30;
+  return 0;
+}
+
+/**
+ * Case-insensitive ranked search over a catalog list. Empty query returns the
+ * list in name order. Results are capped at `limit`.
+ */
+export function searchList(list, query, limit = 50) {
+  if (!query) {
+    return list
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .slice(0, limit);
+  }
+  const q = query.toLowerCase();
+  return list
+    .map((entry) => ({ entry, score: scoreMatch(entry, q) }))
+    .filter((r) => r.score > 0)
+    .sort((a, b) => b.score - a.score || a.entry.name.localeCompare(b.entry.name))
+    .slice(0, limit)
+    .map((r) => r.entry);
+}
+
+/** Component summary for list views (no full props array). */
+export function componentSummary(c) {
+  return {
+    name: c.name,
+    kind: c.kind,
+    description: shortDescription(c.description),
+    ...(c.docsParent ? { parent: c.docsParent } : {}),
+  };
+}
+
+/** Hook / util summary for list views. */
+export function apiSummary(e) {
+  return {
+    name: e.name,
+    kind: e.kind,
+    signature: e.signature,
+    description: shortDescription(e.description),
+  };
+}

--- a/tools/mcp/lib/server.mjs
+++ b/tools/mcp/lib/server.mjs
@@ -1,0 +1,99 @@
+// Minimal, dependency-free MCP server over stdio. MCP is JSON-RPC 2.0; the
+// stdio transport frames each message as one UTF-8 line of JSON. We implement
+// just the methods a tools-only server needs: initialize, tools/list,
+// tools/call, ping (plus the initialized notification).
+//
+// `createHandler` is pure (message in → message out or null), so it can be
+// unit-tested without touching real stdin/stdout. `runStdio` wires it up.
+
+import { TOOL_DEFINITIONS, runTool } from "./tools.mjs";
+import { loadCatalog } from "./catalog.mjs";
+
+const SERVER_INFO = { name: "voidframe-mcp", version: "0.1.0" };
+const DEFAULT_PROTOCOL = "2024-11-05";
+const SUPPORTED_PROTOCOLS = new Set([DEFAULT_PROTOCOL, "2025-03-26", "2025-06-18"]);
+
+function ok(id, result) {
+  return { jsonrpc: "2.0", id, result };
+}
+function err(id, code, message) {
+  return { jsonrpc: "2.0", id, error: { code, message } };
+}
+
+/**
+ * Build a message handler bound to a catalog.
+ * @param {ReturnType<typeof loadCatalog>} catalog
+ * @returns {(msg: any) => object | null} response, or null for notifications
+ */
+export function createHandler(catalog) {
+  return function handle(msg) {
+    if (!msg || msg.jsonrpc !== "2.0" || typeof msg.method !== "string") {
+      return err(msg?.id ?? null, -32600, "Invalid Request");
+    }
+    const { id, method, params } = msg;
+    const isNotification = id === undefined || id === null;
+
+    switch (method) {
+      case "initialize": {
+        const requested = params?.protocolVersion;
+        const protocolVersion = SUPPORTED_PROTOCOLS.has(requested)
+          ? requested
+          : DEFAULT_PROTOCOL;
+        return ok(id, {
+          protocolVersion,
+          capabilities: { tools: {} },
+          serverInfo: SERVER_INFO,
+        });
+      }
+      case "notifications/initialized":
+      case "initialized":
+        return null; // notification, no reply
+      case "ping":
+        return ok(id, {});
+      case "tools/list":
+        return ok(id, { tools: TOOL_DEFINITIONS });
+      case "tools/call": {
+        const name = params?.name;
+        const args = params?.arguments ?? {};
+        try {
+          const data = runTool(name, args, catalog);
+          return ok(id, {
+            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+            isError: Boolean(data && data.error),
+          });
+        } catch (e) {
+          return ok(id, {
+            content: [{ type: "text", text: `Error: ${e.message}` }],
+            isError: true,
+          });
+        }
+      }
+      default:
+        if (isNotification) return null;
+        return err(id, -32601, `Method not found: ${method}`);
+    }
+  };
+}
+
+/** Run the server over process stdin/stdout (newline-delimited JSON). */
+export function runStdio({ input = process.stdin, output = process.stdout, catalog } = {}) {
+  const handler = createHandler(catalog ?? loadCatalog());
+  let buffer = "";
+  input.setEncoding("utf8");
+  input.on("data", (chunk) => {
+    buffer += chunk;
+    let nl;
+    while ((nl = buffer.indexOf("\n")) >= 0) {
+      const line = buffer.slice(0, nl).trim();
+      buffer = buffer.slice(nl + 1);
+      if (!line) continue;
+      let response;
+      try {
+        response = handler(JSON.parse(line));
+      } catch {
+        response = err(null, -32700, "Parse error");
+      }
+      if (response) output.write(JSON.stringify(response) + "\n");
+    }
+  });
+}

--- a/tools/mcp/lib/tools.mjs
+++ b/tools/mcp/lib/tools.mjs
@@ -1,0 +1,140 @@
+// MCP tool definitions and dispatch for the voidframe catalog. Each tool is a
+// pure function of (args, catalog); the transport layer adapts the return
+// value into an MCP tools/call result.
+
+import {
+  searchList,
+  componentSummary,
+  apiSummary,
+} from "./catalog.mjs";
+
+const KINDS = ["element", "layout", "primitive", "provider", "subcomponent", "compat"];
+
+/** JSON Schema tool definitions, returned verbatim from tools/list. */
+export const TOOL_DEFINITIONS = [
+  {
+    name: "list_components",
+    description:
+      "List voidframe-ui components, optionally filtered by kind or a search query. Returns name, kind, and a one-line description.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Case-insensitive search over name and description." },
+        kind: { type: "string", enum: KINDS, description: "Filter to a single component kind." },
+        limit: { type: "number", description: "Max results (default 50)." },
+      },
+    },
+  },
+  {
+    name: "get_component",
+    description:
+      "Get the full documentation for one component: kind, source file, description, and every prop with its type, default, requiredness, and description.",
+    inputSchema: {
+      type: "object",
+      properties: { name: { type: "string", description: "Exact component name, e.g. \"Dialog\"." } },
+      required: ["name"],
+    },
+  },
+  {
+    name: "list_hooks",
+    description: "List voidframe-ui hooks, optionally filtered by a search query.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        limit: { type: "number", description: "Max results (default 50)." },
+      },
+    },
+  },
+  {
+    name: "get_hook",
+    description: "Get the signature and description for one hook.",
+    inputSchema: {
+      type: "object",
+      properties: { name: { type: "string", description: "Exact hook name, e.g. \"useDisclosure\"." } },
+      required: ["name"],
+    },
+  },
+  {
+    name: "list_utils",
+    description: "List voidframe-ui utility functions, optionally filtered by a search query.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        limit: { type: "number", description: "Max results (default 50)." },
+      },
+    },
+  },
+  {
+    name: "get_util",
+    description: "Get the signature and description for one utility function.",
+    inputSchema: {
+      type: "object",
+      properties: { name: { type: "string", description: "Exact utility name, e.g. \"addDays\"." } },
+      required: ["name"],
+    },
+  },
+  {
+    name: "search",
+    description:
+      "Search across components, hooks, and utilities at once. Use when you don't know which category an API belongs to.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        limit: { type: "number", description: "Max results per category (default 10)." },
+      },
+      required: ["query"],
+    },
+  },
+];
+
+function notFound(kind, name) {
+  return { error: `No ${kind} named "${name}". Try the matching list_/search tool to find the exact name.` };
+}
+
+/**
+ * Run a tool by name. Returns a plain JSON-serializable object; throws on an
+ * unknown tool name.
+ */
+export function runTool(name, args = {}, catalog) {
+  switch (name) {
+    case "list_components": {
+      let list = catalog.components;
+      if (args.kind) list = list.filter((c) => c.kind === args.kind);
+      const results = searchList(list, args.query, args.limit ?? 50);
+      return { count: results.length, components: results.map(componentSummary) };
+    }
+    case "get_component": {
+      const c = catalog.byName.component.get(args.name);
+      return c ?? notFound("component", args.name);
+    }
+    case "list_hooks": {
+      const results = searchList(catalog.hooks, args.query, args.limit ?? 50);
+      return { count: results.length, hooks: results.map(apiSummary) };
+    }
+    case "get_hook": {
+      const h = catalog.byName.hook.get(args.name);
+      return h ?? notFound("hook", args.name);
+    }
+    case "list_utils": {
+      const results = searchList(catalog.utils, args.query, args.limit ?? 50);
+      return { count: results.length, utils: results.map(apiSummary) };
+    }
+    case "get_util": {
+      const u = catalog.byName.util.get(args.name);
+      return u ?? notFound("utility", args.name);
+    }
+    case "search": {
+      const limit = args.limit ?? 10;
+      return {
+        components: searchList(catalog.components, args.query, limit).map(componentSummary),
+        hooks: searchList(catalog.hooks, args.query, limit).map(apiSummary),
+        utils: searchList(catalog.utils, args.query, limit).map(apiSummary),
+      };
+    }
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}

--- a/tools/mcp/package.json
+++ b/tools/mcp/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "voidframe-mcp",
+  "version": "0.1.0",
+  "description": "Model Context Protocol server exposing voidframe-ui's component, hook, and utility catalog to AI agents.",
+  "type": "module",
+  "bin": {
+    "voidframe-mcp": "./bin/voidframe-mcp.mjs"
+  },
+  "files": [
+    "bin",
+    "lib",
+    "data",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "voidframe-ui",
+    "mcp",
+    "model-context-protocol",
+    "ai",
+    "agent"
+  ],
+  "author": "DaxAvalon",
+  "license": "MIT",
+  "homepage": "https://daxavalon.github.io/voidframe-ui",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DaxAvalon/voidframe-ui.git",
+    "directory": "tools/mcp"
+  }
+}

--- a/tools/mcp/scripts/sync-data.mjs
+++ b/tools/mcp/scripts/sync-data.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// Copy the generated structured catalog into tools/mcp/data/ so the published
+// `voidframe-mcp` package is self-contained. Run from the monorepo after
+// `npm run docs:extract-props && npm run docs:generate-llms` (which produce
+// docs/public/api/*.json). In-repo the server falls back to docs/public/api,
+// so this is only needed before publishing the standalone package.
+
+import { copyFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = resolve(__dirname, "..", "..", "..", "docs", "public", "api");
+const dest = resolve(__dirname, "..", "data");
+
+mkdirSync(dest, { recursive: true });
+for (const file of ["components.json", "hooks.json", "utils.json"]) {
+  copyFileSync(resolve(src, file), resolve(dest, file));
+  console.log(`✓ ${file}`);
+}
+console.log(`\nCatalog synced to ${dest}/`);


### PR DESCRIPTION
Three bodies of work, each a sequence of self-contained commits. Final state: **367 files / 5,953 vitest tests**, **166/166 Playwright e2e**, typecheck + all lints clean, every size budget met (CSS 46.76/50KB gz).

## Part 1 — Ecosystem & adoption

1. **Security & trust** — `SECURITY.md`, issue/discussion templates, docs Security & Trust page (receipts: 0 runtime deps, OIDC + provenance, SHA-pinned actions, audit gate).
2. **StackBlitz / CodeSandbox buttons** — every playground lifts into a runnable project; imports inferred from real export barrels.
3. **Tailwind preset** — `voidframe-ui/tailwind` maps every `--vf-*` token to runtime-retheming utilities, with a drift-guard test.
4. **Rounded themes** — `soft` / `soft-light`, opting out of zero-radius.
5. **Next.js template** — `--template next` App Router scaffold with pre-hydration theme script.
6. **MCP server** — `voidframe-mcp`, zero-dependency stdio server over the component catalog.
7. **AI Console showcase** — full-page agent console from shipped components.

## Part 2 — Design & functionality review

Browser-verified (166 e2e specs; 171 screenshots across 57 demo sections × 3 themes) + token audit of all 65 stylesheets. Fixed by severity: **P0** soft themes silently rendered as dark (missing tokens.css cascade blocks; drift test added — which also caught midnight's stale accent ramps) · broken `data-vf-motion="never"` reduced-motion opt-out (e2e contract spec added) · keyboard-inoperable NavItem · z-index scale drift with two load-bearing phantom tokens (modal scrim rendered under sticky navbars) · demo illegible in light theme · QR/barcode raw hex → optical tokens · 35 raw font-sizes tokenized · RTL logical properties. Lint ratchet: z-index fallback ban + raw font-size check.

## Part 3 — Style refinement: one visual grammar

A three-way design audit (interaction grammar / foundational polish / weakest components) found the bones excellent (exemplary icon set, consistent overlay surfaces) but the grammar fragmented. Now unified — the four rules:

1. **Selected**: collection selection = `bg-3 + text-0 + 2px var(--vf-accent)` edge (was 6 expressions in 4 colors — amber nav, green tabs, blue wizard, info commit-graph); toggled-on control = `bg-5 + text-0 + border-3` (Button's own `data-active` form, now family-wide). Transient keyboard highlights are hover grammar, not selection.
2. **Hover/pressed**: compact controls → bg-4 + text-0, border never dims (Button's outline hover was *dropping* border 3→2); large rows whisper to bg-2; the ambiguous bg-3 middle tier is gone. **`:active` pressed feedback now exists** (bg-5) — it existed nowhere in 65 stylesheets.
3. **Disabled**: one `--vf-disabled-opacity` token (was 0.3/0.35/0.4/0.5/0.6) + `cursor: not-allowed`.
4. **Surfaces**: interactive floats = bg-1 + border-2; transient hints (tooltips) = bg-5 + border-3; depth **never** via shadows — removed from popconfirm, cascader, split-button, command-input, dev panel, reactflow, hoverable cards, dashboard drag, and the FAB (which was also a *circle* in a zero-radius system — now square + bordered).

Foundational polish: font smoothing on the default root (was opt-in only); the `.vf-h1–h6` scale the tokens documented but never shipped; global caret/placeholder/scrollbar-corner; `--vf-chart-1..8` categorical tokens (charts stop double-coding status colors); line-clamp utilities; one skeleton animation (shimmer) with the duplicate keyframes deduped; ~60 hardcoded letter-spacings onto the three tracking tokens; every transition on the duration/easing tokens (killing the phantom `--vf-transition-duration`); title weight unified at 600.

Weak components brought to the bar: **Select** finally has a dropdown chevron (was pixel-identical to a text input) · **Toggle** got a focus ring, legible off-state, disabled state · **Result/attachments** color emoji (🔍⛔☠📄🖼…) → monochrome glyphs · sort indicators readable + hover-reveal · tabular-nums across tables/stats/pagination/steppers · StatusBar hairline dividers · CursorPagination had zero-padding buttons · Kanban columns bounded with internal scroll + drag lift · Breadcrumb focus ring + current-crumb weight · **Button/IconButton now share exact heights per size tier** via `--vf-control-height-*` (browser-verified 20/25/32px).

Ratchet extended: phantom tokens behind fallbacks now fail lint; raw letter-spacing literals fail without annotation.

## Follow-ups for the maintainer

- Enable GitHub Discussions (Settings → Features) to activate the discussion templates.
- `voidframe-mcp`: run `tools/mcp/scripts/sync-data.mjs` before standalone publish.
- Suggested follow-up PRs: full 576-component a11y audit; high-contrast coverage for midnight/grey/soft themes.

https://claude.ai/code/session_01F4NHDNZS62rFLU6y7p4uZ2